### PR TITLE
fix: CDP minimized window recovery

### DIFF
--- a/src/primitives/puppeteer-backend.ts
+++ b/src/primitives/puppeteer-backend.ts
@@ -20,6 +20,9 @@ import { RateLimitDetector } from './rate-limit-detect.js';
 
 const DEFAULT_SITE = '_default';
 
+/** Delay (ms) after recovery for the compositor to start processing input events. */
+const COMPOSITOR_SETTLE_MS = 500;
+
 /** Named keys that keyboard.press() understands (generates keydown/keypress/keyup sequence). */
 const KNOWN_KEYS = new Set([
   'Enter', 'Tab', 'Escape', 'Backspace', 'Delete', 'Space',
@@ -109,6 +112,95 @@ export class PuppeteerBackend implements Primitives {
 
   private checkRateLimit(step: string): void {
     this.rateLimitDetector?.checkAndThrow(step, this.currentSite);
+  }
+
+  /**
+   * Execute an action with throttle recovery.
+   * If the action returns 'throttled', escalate through recovery levels (1→2→3),
+   * checking visibility before each retry to avoid false negatives.
+   */
+  private async withThrottleRecovery(
+    page: Page,
+    action: () => Promise<'ok' | 'throttled'>,
+    step: string,
+  ): Promise<void> {
+    let result = await action();
+    for (const level of [1, 2, 3] as const) {
+      if (result !== 'throttled') break;
+      await this.recoverFromThrottle(page, level);
+
+      // Check both signals: windowState (OS-level) and visibilityState (compositor-level).
+      // Either one reporting "not ready" is enough to skip retry and escalate.
+      const windowState = await this.getWindowState(page);
+      const visible = await this.isPageVisible(page);
+      if (windowState === 'minimized' || !visible) {
+        console.error(`[site-use] page not ready after level ${level} (window=${windowState}, visible=${visible}) — escalating`);
+        continue;
+      }
+
+      console.error(`[site-use] page visible — waiting ${COMPOSITOR_SETTLE_MS}ms for compositor`);
+      await new Promise((r) => setTimeout(r, COMPOSITOR_SETTLE_MS));
+      result = await action();
+    }
+    if (result === 'throttled') {
+      throw new CdpThrottled(
+        `CDP input events are throttled — ${step} failed after recovery attempts`,
+        { step },
+      );
+    }
+  }
+
+  /**
+   * Check if the page is actually visible to the compositor.
+   * Uses Runtime.evaluate (not Input domain) so it works even when input is throttled.
+   */
+  private async isPageVisible(page: Page): Promise<boolean> {
+    let client;
+    try {
+      client = await page.createCDPSession();
+      const result = await client.send('Runtime.evaluate', {
+        expression: 'document.visibilityState',
+      });
+      return (result as any).result?.value === 'visible';
+    } catch {
+      return false;
+    } finally {
+      try { await client?.detach(); } catch {}
+    }
+  }
+
+  /**
+   * Get the OS window state (normal, minimized, maximized, fullscreen).
+   */
+  private async getWindowState(page: Page): Promise<string> {
+    let client;
+    try {
+      client = await page.createCDPSession();
+      const { windowId } = await client.send('Browser.getWindowForTarget') as { windowId: number };
+      const { bounds } = await client.send('Browser.getWindowBounds', { windowId }) as any;
+      return bounds?.windowState ?? 'unknown';
+    } catch {
+      return 'unknown';
+    } finally {
+      try { await client?.detach(); } catch {}
+    }
+  }
+
+  /**
+   * Ensure Chrome window is not minimized before any CDP operation.
+   * macOS minimization suspends the renderer — AX tree, Input events,
+   * and compositor all stop working. bringToFront is the only way to
+   * un-minimize on macOS.
+   */
+  private async ensureWindowVisible(page: Page): Promise<void> {
+    const windowState = await this.getWindowState(page);
+    console.error(`[site-use] ensureWindowVisible: windowState=${windowState}`);
+    if (windowState === 'minimized') {
+      console.error('[site-use] window is minimized — restoring with bringToFront');
+      await page.bringToFront();
+      // Wait for compositor to become ready after un-minimize
+      await new Promise((r) => setTimeout(r, COMPOSITOR_SETTLE_MS));
+    }
   }
 
   /**
@@ -245,6 +337,21 @@ export class PuppeteerBackend implements Primitives {
     return page;
   }
 
+  /**
+   * Get page for operations that depend on layout/rendering.
+   * Ensures window is not minimized — macOS minimization suspends the renderer,
+   * breaking Accessibility, Input, and screenshot operations.
+   *
+   * Use for: takeSnapshot, click, scroll, scrollIntoView, screenshot.
+   * For layout-independent operations (evaluate, navigate, pressKey, type,
+   * interceptRequest), use getPage() instead.
+   */
+  private async getVisiblePage(): Promise<Page> {
+    const page = await this.getPage();
+    await this.ensureWindowVisible(page);
+    return page;
+  }
+
   async navigate(url: string): Promise<void> {
     this.checkRateLimit('navigate');
     const page = await this.getPage();
@@ -260,7 +367,8 @@ export class PuppeteerBackend implements Primitives {
 
   async takeSnapshot(): Promise<Snapshot> {
     this.checkRateLimit('takeSnapshot');
-    const page = await this.getPage();
+    console.error('[site-use] takeSnapshot() called');
+    const page = await this.getVisiblePage();
     const client = await page.createCDPSession();
 
     try {
@@ -387,6 +495,7 @@ export class PuppeteerBackend implements Primitives {
   async click(uid: string): Promise<void> {
     this.checkRateLimit('click');
     const { page, backendNodeId } = await this.resolveUid(uid, 'click');
+    await this.ensureWindowVisible(page);
     const config = getClickEnhancementConfig();
 
     // Step 1: Wait for element position to stabilize (CSS animations)
@@ -411,22 +520,11 @@ export class PuppeteerBackend implements Primitives {
       : { x: centerX, y: centerY };
 
     if (config.trajectory) {
-      const doClick = () => clickWithTrajectory(page, clickTarget.x, clickTarget.y, {
-        box: elementBox,
-      });
-
-      let result = await doClick();
-      for (const level of [1, 2, 3] as const) {
-        if (result !== 'throttled') break;
-        await this.recoverFromThrottle(page, level);
-        result = await doClick();
-      }
-      if (result === 'throttled') {
-        throw new CdpThrottled(
-          'CDP input events are throttled — click failed after recovery attempts',
-          { step: 'click' },
-        );
-      }
+      await this.withThrottleRecovery(
+        page,
+        () => clickWithTrajectory(page, clickTarget.x, clickTarget.y, { box: elementBox }),
+        'click',
+      );
     } else {
       await page.mouse.click(clickTarget.x, clickTarget.y);
     }
@@ -475,30 +573,22 @@ export class PuppeteerBackend implements Primitives {
 
   async scroll(options: ScrollOptions): Promise<void> {
     this.checkRateLimit('scroll');
-    const page = await this.getPage();
+    const page = await this.getVisiblePage();
     const amount = options.amount ?? 600;
     const direction = options.direction === 'up' ? -1 : 1;
     const totalDelta = amount * direction;
 
-    const doScroll = () => humanScroll(page, 0, totalDelta);
-
-    let result = await doScroll();
-    for (const level of [1, 2, 3] as const) {
-      if (result !== 'throttled') break;
-      await this.recoverFromThrottle(page, level);
-      result = await doScroll();
-    }
-    if (result === 'throttled') {
-      throw new CdpThrottled(
-        'CDP input events are throttled — scroll failed after recovery attempts',
-        { step: 'scroll' },
-      );
-    }
+    await this.withThrottleRecovery(
+      page,
+      () => humanScroll(page, 0, totalDelta),
+      'scroll',
+    );
   }
 
   async scrollIntoView(uid: string): Promise<void> {
     this.checkRateLimit('scrollIntoView');
     const { page, backendNodeId } = await this.resolveUid(uid, 'scrollIntoView');
+    await this.ensureWindowVisible(page);
     await scrollElementIntoView(page, backendNodeId);
   }
 
@@ -509,7 +599,7 @@ export class PuppeteerBackend implements Primitives {
   }
 
   async screenshot(): Promise<string> {
-    const page = await this.getPage();
+    const page = await this.getVisiblePage();
     const result = await page.screenshot({ encoding: 'base64', type: 'png' });
     // Puppeteer may return Buffer or string depending on version
     if (typeof result === 'string') return result;

--- a/tests/unit/puppeteer-backend.test.ts
+++ b/tests/unit/puppeteer-backend.test.ts
@@ -100,6 +100,147 @@ describe('PuppeteerBackend', () => {
     });
   });
 
+  describe('ensureWindowVisible', () => {
+    // Helper: create CDP session mock with configurable window state
+    function createWindowStateMock(windowState: string) {
+      return {
+        send: vi.fn().mockImplementation((method: string) => {
+          if (method === 'Browser.getWindowForTarget') return Promise.resolve({ windowId: 1 });
+          if (method === 'Browser.getWindowBounds') return Promise.resolve({ bounds: { windowState } });
+          if (method === 'Accessibility.getFullAXTree') {
+            return Promise.resolve({ nodes: [{ nodeId: 'ax-1', role: { value: 'button' }, name: { value: 'OK' }, backendDOMNodeId: 101, ignored: false, properties: [] }] });
+          }
+          if (method === 'DOM.describeNode') return Promise.resolve({ node: { nodeId: 10 } });
+          if (method === 'DOM.getBoxModel') return Promise.resolve({ model: { content: [100, 200, 200, 200, 200, 240, 100, 240] } });
+          return Promise.resolve({});
+        }),
+        detach: vi.fn().mockResolvedValue(undefined),
+      };
+    }
+
+    it('does NOT call bringToFront in getRawPage (layout-independent)', async () => {
+      const page = createMockPage();
+      mockNewPage.mockResolvedValue(page);
+      mockCreateCDPSession.mockResolvedValue(createWindowStateMock('minimized'));
+
+      const backend = new PuppeteerBackend(mockBrowser as any);
+      await backend.getRawPage();
+
+      expect(page.bringToFront).not.toHaveBeenCalled();
+    });
+
+    it('does NOT call bringToFront in navigate (layout-independent)', async () => {
+      const page = createMockPage();
+      mockNewPage.mockResolvedValue(page);
+      mockCreateCDPSession.mockResolvedValue(createWindowStateMock('minimized'));
+
+      const backend = new PuppeteerBackend(mockBrowser as any);
+      await backend.navigate('https://x.com/home');
+
+      expect(page.bringToFront).not.toHaveBeenCalled();
+    });
+
+    it('does NOT call bringToFront in evaluate (layout-independent)', async () => {
+      const page = createMockPage();
+      mockNewPage.mockResolvedValue(page);
+      mockCreateCDPSession.mockResolvedValue(createWindowStateMock('minimized'));
+
+      const backend = new PuppeteerBackend(mockBrowser as any);
+      await backend.evaluate('1+1');
+
+      expect(page.bringToFront).not.toHaveBeenCalled();
+    });
+
+    it('does NOT call bringToFront in pressKey (layout-independent)', async () => {
+      const page = createMockPage();
+      mockNewPage.mockResolvedValue(page);
+      mockCreateCDPSession.mockResolvedValue(createWindowStateMock('minimized'));
+
+      const backend = new PuppeteerBackend(mockBrowser as any);
+      await backend.pressKey('Enter');
+
+      expect(page.bringToFront).not.toHaveBeenCalled();
+    });
+
+    it('calls bringToFront in takeSnapshot when minimized', async () => {
+      const page = createMockPage();
+      mockNewPage.mockResolvedValue(page);
+      mockCreateCDPSession.mockResolvedValue(createWindowStateMock('minimized'));
+
+      const backend = new PuppeteerBackend(mockBrowser as any);
+      await backend.takeSnapshot();
+
+      expect(page.bringToFront).toHaveBeenCalled();
+    });
+
+    it('calls bringToFront in scroll when minimized', async () => {
+      const page = createMockPage();
+      mockNewPage.mockResolvedValue(page);
+      mockCreateCDPSession.mockResolvedValue(createWindowStateMock('minimized'));
+
+      const backend = new PuppeteerBackend(mockBrowser as any);
+      await backend.scroll({ direction: 'down' });
+
+      expect(page.bringToFront).toHaveBeenCalled();
+    });
+
+    it('calls bringToFront in screenshot when minimized', async () => {
+      const page = createMockPage();
+      mockNewPage.mockResolvedValue(page);
+      mockCreateCDPSession.mockResolvedValue(createWindowStateMock('minimized'));
+
+      const backend = new PuppeteerBackend(mockBrowser as any);
+      await backend.screenshot();
+
+      expect(page.bringToFront).toHaveBeenCalled();
+    });
+
+    it('does not call bringToFront in takeSnapshot when window is normal', async () => {
+      const page = createMockPage();
+      mockNewPage.mockResolvedValue(page);
+      mockCreateCDPSession.mockResolvedValue(createWindowStateMock('normal'));
+
+      const backend = new PuppeteerBackend(mockBrowser as any);
+      await backend.takeSnapshot();
+
+      expect(page.bringToFront).not.toHaveBeenCalled();
+    });
+
+    it('calls bringToFront in click when minimized', async () => {
+      const page = createMockPage();
+      mockNewPage.mockResolvedValue(page);
+
+      // Phase 1: takeSnapshot with normal window (populates uid map)
+      mockCreateCDPSession.mockResolvedValue(createWindowStateMock('normal'));
+      const backend = new PuppeteerBackend(mockBrowser as any);
+      await backend.takeSnapshot();
+
+      // Phase 2: click with minimized window
+      mockCreateCDPSession.mockResolvedValue(createWindowStateMock('minimized'));
+      page.bringToFront.mockClear();
+      await backend.click('1');
+
+      expect(page.bringToFront).toHaveBeenCalled();
+    });
+
+    it('calls bringToFront in scrollIntoView when minimized', async () => {
+      const page = createMockPage();
+      mockNewPage.mockResolvedValue(page);
+
+      // Phase 1: takeSnapshot with normal window (populates uid map)
+      mockCreateCDPSession.mockResolvedValue(createWindowStateMock('normal'));
+      const backend = new PuppeteerBackend(mockBrowser as any);
+      await backend.takeSnapshot();
+
+      // Phase 2: scrollIntoView with minimized window
+      mockCreateCDPSession.mockResolvedValue(createWindowStateMock('minimized'));
+      page.bringToFront.mockClear();
+      await backend.scrollIntoView('1');
+
+      expect(page.bringToFront).toHaveBeenCalled();
+    });
+  });
+
   describe('navigate', () => {
     it('calls page.goto with load waitUntil', async () => {
       const backend = new PuppeteerBackend(mockBrowser as any);
@@ -397,6 +538,7 @@ describe('PuppeteerBackend', () => {
           }
           if (method === 'DOM.describeNode') return Promise.resolve({ node: { nodeId: 10 } });
           if (method === 'DOM.getBoxModel') return Promise.resolve({ model: { content: [100, 200, 200, 200, 200, 240, 100, 240] } });
+          if (method === 'Runtime.evaluate') return Promise.resolve({ result: { value: 'visible' } });
           return Promise.resolve({});
         }),
         detach: vi.fn().mockResolvedValue(undefined),
@@ -436,6 +578,7 @@ describe('PuppeteerBackend', () => {
           }
           if (method === 'DOM.describeNode') return Promise.resolve({ node: { nodeId: 10 } });
           if (method === 'DOM.getBoxModel') return Promise.resolve({ model: { content: [100, 200, 200, 200, 200, 240, 100, 240] } });
+          if (method === 'Runtime.evaluate') return Promise.resolve({ result: { value: 'visible' } });
           return Promise.resolve({});
         }),
         detach: vi.fn().mockResolvedValue(undefined),
@@ -474,6 +617,7 @@ describe('PuppeteerBackend', () => {
           }
           if (method === 'DOM.describeNode') return Promise.resolve({ node: { nodeId: 10 } });
           if (method === 'DOM.getBoxModel') return Promise.resolve({ model: { content: [100, 200, 200, 200, 200, 240, 100, 240] } });
+          if (method === 'Runtime.evaluate') return Promise.resolve({ result: { value: 'hidden' } });
           return Promise.resolve({});
         }),
         detach: vi.fn().mockResolvedValue(undefined),
@@ -485,6 +629,58 @@ describe('PuppeteerBackend', () => {
       await backend.takeSnapshot();
 
       await expect(backend.click('1')).rejects.toThrow(CdpThrottled);
+    });
+
+    it('skips retry and escalates when page stays hidden after recovery (click)', async () => {
+      setupClickMocks();
+      const page = createMockPage();
+      mockNewPage.mockResolvedValue(page);
+
+      const { getClickEnhancementConfig } = await import('../../src/config.js');
+      vi.mocked(getClickEnhancementConfig).mockReturnValue({
+        trajectory: true,
+        jitter: false,
+        occlusionCheck: false,
+      });
+
+      const { clickWithTrajectory } = await import('../../src/primitives/click-enhanced.js');
+      vi.mocked(clickWithTrajectory)
+        .mockResolvedValueOnce('throttled')
+        .mockResolvedValueOnce('ok');
+
+      let pageVisible = false;
+      const cdpSession = {
+        send: vi.fn().mockImplementation((method: string, params?: any) => {
+          if (method === 'Accessibility.getFullAXTree') {
+            return Promise.resolve({ nodes: [{ nodeId: 'ax-1', role: { value: 'button' }, name: { value: 'Follow' }, backendDOMNodeId: 101, ignored: false, properties: [] }] });
+          }
+          if (method === 'DOM.describeNode') return Promise.resolve({ node: { nodeId: 10 } });
+          if (method === 'DOM.getBoxModel') return Promise.resolve({ model: { content: [100, 200, 200, 200, 200, 240, 100, 240] } });
+          if (method === 'Browser.getWindowForTarget') return Promise.resolve({ windowId: 1 });
+          if (method === 'Browser.getWindowBounds') return Promise.resolve({ bounds: { windowState: pageVisible ? 'normal' : 'minimized' } });
+          if (method === 'Browser.setWindowBounds') { pageVisible = true; return Promise.resolve({}); }
+          if (method === 'Runtime.evaluate') {
+            if (params?.expression === 'document.visibilityState') {
+              return Promise.resolve({ result: { value: pageVisible ? 'visible' : 'hidden' } });
+            }
+            return Promise.resolve({ result: { value: false } });
+          }
+          return Promise.resolve({});
+        }),
+        detach: vi.fn().mockResolvedValue(undefined),
+      };
+      mockCreateCDPSession.mockResolvedValue(cdpSession);
+
+      const backend = new PuppeteerBackend(mockBrowser as any);
+      await backend.takeSnapshot();
+      await backend.click('1');
+
+      // Level 3 was reached (setWindowBounds), levels 1 & 2 skipped retry
+      expect(cdpSession.send).toHaveBeenCalledWith('Browser.setWindowBounds', {
+        windowId: 1,
+        bounds: { windowState: 'normal' },
+      });
+      expect(clickWithTrajectory).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -532,7 +728,10 @@ describe('PuppeteerBackend', () => {
         .mockResolvedValueOnce('ok');
 
       const cdpSession = {
-        send: vi.fn().mockResolvedValue({}),
+        send: vi.fn().mockImplementation((method: string) => {
+          if (method === 'Runtime.evaluate') return Promise.resolve({ result: { value: 'visible' } });
+          return Promise.resolve({});
+        }),
         detach: vi.fn().mockResolvedValue(undefined),
       };
       mockCreateCDPSession.mockResolvedValue(cdpSession);
@@ -555,7 +754,10 @@ describe('PuppeteerBackend', () => {
         .mockResolvedValueOnce('ok');
 
       const cdpSession = {
-        send: vi.fn().mockResolvedValue({}),
+        send: vi.fn().mockImplementation((method: string) => {
+          if (method === 'Runtime.evaluate') return Promise.resolve({ result: { value: 'visible' } });
+          return Promise.resolve({});
+        }),
         detach: vi.fn().mockResolvedValue(undefined),
       };
       mockCreateCDPSession.mockResolvedValue(cdpSession);
@@ -577,6 +779,7 @@ describe('PuppeteerBackend', () => {
       const cdpSession = {
         send: vi.fn().mockImplementation((method: string) => {
           if (method === 'Browser.getWindowForTarget') return Promise.resolve({ windowId: 1 });
+          if (method === 'Runtime.evaluate') return Promise.resolve({ result: { value: 'hidden' } });
           return Promise.resolve({});
         }),
         detach: vi.fn().mockResolvedValue(undefined),
@@ -587,6 +790,43 @@ describe('PuppeteerBackend', () => {
       const backend = new PuppeteerBackend(mockBrowser as any);
 
       await expect(backend.scroll({ direction: 'down' })).rejects.toThrow(CdpThrottled);
+    });
+
+    it('skips retry and escalates when page stays hidden after recovery (scroll)', async () => {
+      const page = createMockPage();
+      mockNewPage.mockResolvedValue(page);
+
+      const { humanScroll } = await import('../../src/primitives/scroll-enhanced.js');
+      vi.mocked(humanScroll)
+        .mockResolvedValueOnce('throttled')
+        .mockResolvedValueOnce('ok');
+
+      let pageVisible = false;
+      const cdpSession = {
+        send: vi.fn().mockImplementation((method: string, params?: any) => {
+          if (method === 'Browser.getWindowForTarget') return Promise.resolve({ windowId: 1 });
+          if (method === 'Browser.getWindowBounds') return Promise.resolve({ bounds: { windowState: pageVisible ? 'normal' : 'minimized' } });
+          if (method === 'Browser.setWindowBounds') { pageVisible = true; return Promise.resolve({}); }
+          if (method === 'Runtime.evaluate') {
+            if (params?.expression === 'document.visibilityState') {
+              return Promise.resolve({ result: { value: pageVisible ? 'visible' : 'hidden' } });
+            }
+            return Promise.resolve({ result: { value: false } });
+          }
+          return Promise.resolve({});
+        }),
+        detach: vi.fn().mockResolvedValue(undefined),
+      };
+      mockCreateCDPSession.mockResolvedValue(cdpSession);
+
+      const backend = new PuppeteerBackend(mockBrowser as any);
+      await backend.scroll({ direction: 'down' });
+
+      expect(cdpSession.send).toHaveBeenCalledWith('Browser.setWindowBounds', {
+        windowId: 1,
+        bounds: { windowState: 'normal' },
+      });
+      expect(humanScroll).toHaveBeenCalledTimes(2);
     });
   });
 


### PR DESCRIPTION
## Summary

- Detect minimized Chrome window before layout-dependent CDP operations and restore with `bringToFront` + compositor settle
- Fix false negative in existing click/scroll throttle recovery loop: add `visibilityState` check + 500ms compositor settle after each recovery level
- Extract duplicated recovery loop from `click()` and `scroll()` into shared `withThrottleRecovery()`

## Problem

When Chrome is minimized on macOS (Cmd+M), two failure modes occur:
- **scroll**: `Input.dispatchMouseWheelEvent` hangs completely → 30s protocol timeout (recovery loop never entered)
- **click**: recovery Level 2 `bringToFront` restores window but `visibility` stays `hidden` → click returns `'ok'` (false negative) → tab never switches → `StateTransitionFailed`

Both reproduced on `main` and verified fixed on this branch. See `.dev/docs/cdp-minimized-window-recovery.md` for full analysis, logs, and Q&A.

## Changes

### `src/primitives/puppeteer-backend.ts` (+116/-4)
- **New methods**: `getWindowState()`, `ensureWindowVisible()`, `getVisiblePage()`, `isPageVisible()`, `withThrottleRecovery()`
- **Layer 1 (prevention)**: `ensureWindowVisible` before layout-dependent ops — `takeSnapshot`, `click`, `scroll`, `scrollIntoView`, `screenshot`
- **Layer 2 (fallback)**: `withThrottleRecovery` checks `visibilityState` + waits `COMPOSITOR_SETTLE_MS` after each recovery level — used by `click` and `scroll` only
- **Refactor**: extract ~15 lines of duplicated recovery loop from `click()` and `scroll()` into `withThrottleRecovery()`

### `tests/unit/puppeteer-backend.test.ts` (+244)
- 10 `ensureWindowVisible` tests (5 positive, 4 negative, 1 normal window)
- 2 escalation tests (visibility-based upgrade)
- 6 existing recovery tests updated for new logic

### `.dev/docs/cdp-minimized-window-recovery.md`
Full design doc with root cause analysis, solution design, reproduced test logs (main vs fix), and Q&A.

## Test plan

- [x] 60 unit tests pass (`pnpm vitest run tests/unit/puppeteer-backend.test.ts`)
- [x] Manual: `twitter search --fetch` with Chrome minimized → ✅ (was: protocol timeout)
- [x] Manual: `twitter feed --tab following --fetch` with Chrome minimized → ✅ (was: false negative → StateTransitionFailed)
- [x] Manual: Layer 2 isolated test (disable `ensureWindowVisible`, verify recovery loop alone) → ✅