### PR TITLE
refactor(twitter): profile posts/replies output FeedItem[] with top-level inReplyTo

### DIFF
--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -55,6 +55,12 @@ export interface FeedItem {
   links: string[];
   /** Site-specific fields (metrics, categories, etc.) */
   siteMeta: Record<string, unknown>;
+  /** Reply target — present when this item is a reply to another post. */
+  inReplyTo?: {
+    handle: string;
+    id: string;
+    text?: string;
+  };
 }
 
 export interface FeedMeta {

--- a/src/sites/twitter/__tests__/extractors.test.ts
+++ b/src/sites/twitter/__tests__/extractors.test.ts
@@ -18,7 +18,7 @@ import {
   GRAPHQL_USER_TWEETS_AND_REPLIES_PATTERN,
 } from '../extractors.js';
 import type { RawTweetData, UserProfile, ProfileResult } from '../types.js';
-import { InReplyToSchema, ProfileWithTimelineSchema } from '../types.js';
+import { InReplyToSchema } from '../types.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -1246,38 +1246,6 @@ describe('InReplyToSchema', () => {
   });
 });
 
-describe('ProfileWithTimelineSchema', () => {
-  it('accepts posts and replies arrays', () => {
-    const result = ProfileWithTimelineSchema.parse({
-      user: {
-        userId: '1', handle: 'test', displayName: 'Test', bio: '',
-        followersCount: 0, followingCount: 0, tweetsCount: 0, likesCount: 0,
-        verified: false, createdAt: '2020-01-01',
-      },
-      relationship: null,
-      posts: [],
-      replies: [],
-      errors: ['replies timed out'],
-    });
-    expect(result.posts).toEqual([]);
-    expect(result.replies).toEqual([]);
-    expect(result.errors).toEqual(['replies timed out']);
-  });
-
-  it('posts/replies/errors are optional', () => {
-    const result = ProfileWithTimelineSchema.parse({
-      user: {
-        userId: '1', handle: 'test', displayName: 'Test', bio: '',
-        followersCount: 0, followingCount: 0, tweetsCount: 0, likesCount: 0,
-        verified: false, createdAt: '2020-01-01',
-      },
-      relationship: null,
-    });
-    expect(result.posts).toBeUndefined();
-    expect(result.replies).toBeUndefined();
-    expect(result.errors).toBeUndefined();
-  });
-});
 
 describe('GRAPHQL_USER_TWEETS_PATTERN', () => {
   it('matches UserTweets endpoint', () => {

--- a/src/sites/twitter/__tests__/profile.test.ts
+++ b/src/sites/twitter/__tests__/profile.test.ts
@@ -298,15 +298,12 @@ describe('getProfile — timeline dispatch', () => {
     expect(result.posts).toBeDefined();
     expect(result.posts!.length).toBeLessThanOrEqual(5);
     expect(result.posts!.length).toBeGreaterThan(0);
-    // Posts should not include ads
-    for (const post of result.posts!) {
-      expect(post.isAd).toBe(false);
-    }
-    // Each post has the expected structure
+    // Each post is a FeedItem with expected structure
     for (const post of result.posts!) {
       expect(post.id).toBeDefined();
       expect(post.author).toBeDefined();
       expect(post.text).toBeDefined();
+      expect(post.siteMeta).toBeDefined();
     }
   });
 
@@ -377,10 +374,12 @@ describe('getProfile — timeline dispatch', () => {
     expect(result.replies!.length).toBeGreaterThan(0);
     expect(result.replies!.length).toBeLessThanOrEqual(5);
 
-    // All replies should be by the target user
+    // All replies should be by the target user with inReplyTo at top level
     for (const reply of result.replies!) {
       expect(reply.author.handle.toLowerCase()).toBe('hwwaanng');
       expect(reply.inReplyTo).toBeDefined();
+      expect(reply.inReplyTo!.id).toBeTruthy();     // generic field name (not tweetId)
+      expect(reply.inReplyTo!.handle).toBeTruthy();
     }
 
     // At least one reply should have inReplyTo.text enriched from the tweet map

--- a/src/sites/twitter/feed-item.ts
+++ b/src/sites/twitter/feed-item.ts
@@ -15,7 +15,7 @@ export const TwitterSiteMetaSchema = z.object({
   surfaceReason: z.enum(['original', 'retweet', 'quote', 'reply']),
   surfacedBy: z.string().optional(),
   quotedTweet: z.unknown().optional(),
-  inReplyTo: z.object({ handle: z.string(), tweetId: z.string() }).optional(),
+  inReplyTo: z.object({ handle: z.string(), tweetId: z.string(), text: z.string().optional() }).optional(),
 });
 
 export type TwitterSiteMeta = z.infer<typeof TwitterSiteMetaSchema>;
@@ -48,5 +48,12 @@ export function tweetToFeedItem(tweet: Tweet): FeedItem {
     media: tweet.media,
     links: tweet.links,
     siteMeta,
+    ...(tweet.inReplyTo !== undefined && {
+      inReplyTo: {
+        handle: tweet.inReplyTo.handle,
+        id: tweet.inReplyTo.tweetId,
+        ...(tweet.inReplyTo.text !== undefined && { text: tweet.inReplyTo.text }),
+      },
+    }),
   };
 }

--- a/src/sites/twitter/profile.ts
+++ b/src/sites/twitter/profile.ts
@@ -1,5 +1,7 @@
 import type { Primitives } from '../../primitives/types.js';
 import type { ProfileResult, ProfileWithTimelineResult, FollowListResult, Tweet } from './types.js';
+import type { FeedItem } from '../../registry/types.js';
+import { tweetToFeedItem } from './feed-item.js';
 import { resolveHandle, checkLoginRedirect, checkProfileError, getSelfHandle } from './navigate.js';
 import { parseProfileResponse, parseGraphQLTimeline, parseTweet, GRAPHQL_PROFILE_PATTERN, GRAPHQL_USER_TWEETS_PATTERN, GRAPHQL_USER_TWEETS_AND_REPLIES_PATTERN } from './extractors.js';
 import { SiteUseError } from '../../errors.js';
@@ -214,7 +216,8 @@ async function getProfileWithTimeline(
           const posts = [...tweetsCollector.items]
             .map(parseTweet)
             .filter(t => !t.isAd)
-            .slice(0, count);
+            .slice(0, count)
+            .map(tweetToFeedItem);
 
           result.posts = posts;
           rootSpan.set('postsReturned', posts.length);
@@ -255,7 +258,7 @@ async function collectReplies(
   handle: string,
   count: number,
   span: import('../../trace.js').SpanHandle,
-): Promise<Tweet[]> {
+): Promise<FeedItem[]> {
   const repliesCollector = createDataCollector<import('./types.js').RawTweetData>();
 
   const cleanup = await primitives.interceptRequest(
@@ -374,8 +377,9 @@ async function collectReplies(
       }
     }
 
-    span.set('repliesReturned', targetReplies.length);
-    return targetReplies;
+    const feedItems = targetReplies.map(tweetToFeedItem);
+    span.set('repliesReturned', feedItems.length);
+    return feedItems;
   } finally {
     cleanup();
   }

--- a/src/sites/twitter/types.ts
+++ b/src/sites/twitter/types.ts
@@ -282,13 +282,13 @@ export type ProfileResult = z.infer<typeof ProfileResultSchema>;
 
 // --- ProfileWithTimelineResult ---
 
-export const ProfileWithTimelineSchema = ProfileResultSchema.extend({
-  posts: z.array(TweetSchema).optional(),
-  replies: z.array(TweetSchema).optional(),
-  errors: z.array(z.string()).optional(),
-});
+import type { FeedItem } from '../../registry/types.js';
 
-export type ProfileWithTimelineResult = z.infer<typeof ProfileWithTimelineSchema>;
+export interface ProfileWithTimelineResult extends ProfileResult {
+  posts?: FeedItem[];
+  replies?: FeedItem[];
+  errors?: string[];
+}
 
 // --- FollowListResult ---
 


### PR DESCRIPTION
## Summary

- Profile `--posts`/`--replies` output changed from `Tweet[]` to `FeedItem[]`, consistent with feed/search/tweet_detail
- `FeedItem` gains a top-level `inReplyTo` field (generic: `handle` + `id` + optional `text`), promoting reply context from Twitter-specific `siteMeta` to framework level
- `TwitterSiteMetaSchema.inReplyTo` gains `text` field to sync with `InReplyToSchema` (fixes silent stripping on persist path)

## Changes (4 files + 2 test files)

| File | Change |
|------|--------|
| `src/registry/types.ts` | `FeedItem.inReplyTo?: { handle, id, text? }` |
| `src/sites/twitter/feed-item.ts` | siteMeta schema adds `text`; `tweetToFeedItem` maps `inReplyTo` to FeedItem top-level (`tweetId` → `id`) |
| `src/sites/twitter/types.ts` | `ProfileWithTimelineResult` uses `FeedItem[]` instead of `Tweet[]`; drops `ProfileWithTimelineSchema` (no Zod runtime validation needed) |
| `src/sites/twitter/profile.ts` | Posts and replies piped through `tweetToFeedItem` before returning |
| Tests | Assertions updated for FeedItem structure; `ProfileWithTimelineSchema` tests removed |

## Not changed

- `store-adapter.ts` — reads `siteMeta.inReplyTo.handle` for mentions index, siteMeta copy preserved
- `extractors.ts` — `InReplyToSchema` already has `text`, no change needed
- Framework pipeline — `codegen.ts`, `tool-wrapper.ts` unaffected

## Test plan

- [x] 261 twitter tests pass (12 test files)
- [x] Build succeeds with zero TS errors

Follows up on #27 (merged). Part of #24.