### PR TITLE
perf: two-phase scroll for collectData

### DIFF
--- a/src/primitives/puppeteer-backend.ts
+++ b/src/primitives/puppeteer-backend.ts
@@ -697,6 +697,7 @@ export class PuppeteerBackend implements Primitives {
         page.off('response', responseListener);
       },
       reset: () => { validRequests = new Set(); },
+      hasPending: () => validRequests.size > 0,
     };
   }
 

--- a/src/primitives/puppeteer-backend.ts
+++ b/src/primitives/puppeteer-backend.ts
@@ -684,7 +684,9 @@ export class PuppeteerBackend implements Primitives {
           body,
         });
       } catch {
-        // Response body may be unavailable (e.g., already consumed or redirect)
+        // Response body may be unavailable (e.g., already consumed or redirect).
+        // Still must remove request from tracking so hasPending() doesn't stick.
+        validRequests.delete(response.request());
       }
     };
 

--- a/src/primitives/throttle.ts
+++ b/src/primitives/throttle.ts
@@ -46,8 +46,11 @@ export function createThrottledPrimitives(
     click: (uid) => throttledAndCounted(() => inner.click(uid)),
     // Note: options.delay is per-keystroke delay inside keyboard.type — stacks with throttle delay above.
     type: (uid, text, options) => throttledAndCounted(() => inner.type(uid, text, options)),
-    scroll: (options) => throttledAndCounted(() => inner.scroll(options)),
-    scrollIntoView: (uid) => throttledAndCounted(() => inner.scrollIntoView(uid)),
+    // Exempt — humanScroll internals already provide humanization (bell curve,
+    // jitter, step delays). Throttle on top makes continuous browsing scroll
+    // unnaturally slow. Callers add their own inter-scroll pauses when needed.
+    scroll: (options) => inner.scroll(options),
+    scrollIntoView: (uid) => inner.scrollIntoView(uid),
 
     // Throttled but NOT counted
     takeSnapshot: () => inner.takeSnapshot(),

--- a/src/primitives/types.ts
+++ b/src/primitives/types.ts
@@ -48,6 +48,8 @@ export interface InterceptControl {
    * even if the response event fires or body resolves after reset().
    */
   reset: () => void;
+  /** True if any tracked request has not yet received a response. */
+  hasPending: () => boolean;
 }
 
 // --- Throttle config ---

--- a/src/sites/twitter/__tests__/ensure-page.test.ts
+++ b/src/sites/twitter/__tests__/ensure-page.test.ts
@@ -15,7 +15,7 @@ function createMockPrimitives(overrides: Partial<Primitives> = {}): Primitives {
     evaluate: vi.fn().mockResolvedValue(undefined),
     screenshot: vi.fn().mockResolvedValue('base64png'),
     interceptRequest: vi.fn().mockResolvedValue(() => {}),
-    interceptRequestWithControl: vi.fn().mockResolvedValue({ cleanup: () => {}, reset: () => {} }),
+    interceptRequestWithControl: vi.fn().mockResolvedValue({ cleanup: () => {}, reset: () => {}, hasPending: () => false }),
     getRawPage: vi.fn().mockResolvedValue({}),
     ...overrides,
   };

--- a/src/sites/twitter/__tests__/follow-list.test.ts
+++ b/src/sites/twitter/__tests__/follow-list.test.ts
@@ -23,7 +23,7 @@ function createMockPrimitives(overrides: Partial<Primitives> = {}): Primitives {
     evaluate: vi.fn().mockResolvedValue(null),
     screenshot: vi.fn().mockResolvedValue('base64png'),
     interceptRequest: vi.fn().mockResolvedValue(() => {}),
-    interceptRequestWithControl: vi.fn().mockResolvedValue({ cleanup: () => {}, reset: () => {} }),
+    interceptRequestWithControl: vi.fn().mockResolvedValue({ cleanup: () => {}, reset: () => {}, hasPending: () => false }),
     getRawPage: vi.fn().mockResolvedValue({}),
     ...overrides,
   };

--- a/src/sites/twitter/__tests__/follow.test.ts
+++ b/src/sites/twitter/__tests__/follow.test.ts
@@ -13,7 +13,7 @@ function createMockPrimitives(overrides: Partial<Primitives> = {}): Primitives {
     evaluate: vi.fn().mockResolvedValue(undefined),
     screenshot: vi.fn().mockResolvedValue('base64png'),
     interceptRequest: vi.fn().mockResolvedValue(() => {}),
-    interceptRequestWithControl: vi.fn().mockResolvedValue({ cleanup: () => {}, reset: () => {} }),
+    interceptRequestWithControl: vi.fn().mockResolvedValue({ cleanup: () => {}, reset: () => {}, hasPending: () => false }),
     getRawPage: vi.fn().mockResolvedValue({}),
     ...overrides,
   };

--- a/src/sites/twitter/__tests__/profile.test.ts
+++ b/src/sites/twitter/__tests__/profile.test.ts
@@ -31,7 +31,7 @@ function createMockPrimitives(overrides: Partial<Primitives> = {}): Primitives {
     evaluate: vi.fn().mockResolvedValue(null),
     screenshot: vi.fn().mockResolvedValue('base64png'),
     interceptRequest: vi.fn().mockResolvedValue(() => {}),
-    interceptRequestWithControl: vi.fn().mockResolvedValue({ cleanup: () => {}, reset: () => {} }),
+    interceptRequestWithControl: vi.fn().mockResolvedValue({ cleanup: () => {}, reset: () => {}, hasPending: () => false }),
     getRawPage: vi.fn().mockResolvedValue({}),
     ...overrides,
   };

--- a/src/sites/twitter/__tests__/profile.test.ts
+++ b/src/sites/twitter/__tests__/profile.test.ts
@@ -279,10 +279,14 @@ describe('getProfile — timeline dispatch', () => {
       interceptRequest: vi.fn().mockImplementation(async (pattern: RegExp, handler: any) => {
         if (pattern.source.includes('UserByScreenName')) {
           handlers.set('profile', handler);
-        } else if (pattern.source.includes('UserTweets')) {
-          handlers.set('tweets', handler);
         }
         return () => {};
+      }),
+      interceptRequestWithControl: vi.fn().mockImplementation(async (pattern: RegExp, handler: any) => {
+        if (pattern.source.includes('UserTweets')) {
+          handlers.set('tweets', handler);
+        }
+        return { cleanup: () => {}, reset: () => {}, hasPending: () => false };
       }),
       evaluate: vi.fn()
         .mockResolvedValueOnce('https://x.com/hwwaanng')  // checkLoginRedirect
@@ -334,12 +338,14 @@ describe('getProfile — timeline dispatch', () => {
       interceptRequest: vi.fn().mockImplementation(async (pattern: RegExp, handler: any) => {
         if (pattern.source.includes('UserByScreenName')) {
           handlers.set('profile', handler);
-        } else if (pattern.source.includes('UserTweetsAndReplies')) {
-          handlers.set('replies', handler);
-        } else if (pattern.source.includes('UserTweets')) {
-          handlers.set('tweets', handler);
         }
         return () => {};
+      }),
+      interceptRequestWithControl: vi.fn().mockImplementation(async (pattern: RegExp, handler: any) => {
+        if (pattern.source.includes('UserTweetsAndReplies')) {
+          handlers.set('replies', handler);
+        }
+        return { cleanup: () => {}, reset: () => {}, hasPending: () => false };
       }),
       evaluate: vi.fn()
         .mockResolvedValueOnce('https://x.com/hwwaanng')  // checkLoginRedirect
@@ -412,12 +418,16 @@ describe('getProfile — timeline dispatch', () => {
       interceptRequest: vi.fn().mockImplementation(async (pattern: RegExp, handler: any) => {
         if (pattern.source.includes('UserByScreenName')) {
           handlers.set('profile', handler);
-        } else if (pattern.source.includes('UserTweetsAndReplies')) {
+        }
+        return () => {};
+      }),
+      interceptRequestWithControl: vi.fn().mockImplementation(async (pattern: RegExp, handler: any) => {
+        if (pattern.source.includes('UserTweetsAndReplies')) {
           handlers.set('replies', handler);
         } else if (pattern.source.includes('UserTweets')) {
           handlers.set('tweets', handler);
         }
-        return () => {};
+        return { cleanup: () => {}, reset: () => {}, hasPending: () => false };
       }),
       evaluate: vi.fn()
         .mockResolvedValueOnce('https://x.com/hwwaanng')  // checkLoginRedirect
@@ -463,10 +473,15 @@ describe('getProfile — timeline dispatch', () => {
         interceptedPatterns.push(pattern.source);
         if (pattern.source.includes('UserByScreenName')) {
           handlers.set('profile', handler);
-        } else if (pattern.source.includes('UserTweetsAndReplies')) {
-          handlers.set('replies', handler);
         }
         return () => {};
+      }),
+      interceptRequestWithControl: vi.fn().mockImplementation(async (pattern: RegExp, handler: any) => {
+        interceptedPatterns.push(pattern.source);
+        if (pattern.source.includes('UserTweetsAndReplies')) {
+          handlers.set('replies', handler);
+        }
+        return { cleanup: () => {}, reset: () => {}, hasPending: () => false };
       }),
       evaluate: vi.fn()
         .mockResolvedValueOnce('https://x.com/hwwaanng')  // checkLoginRedirect
@@ -494,7 +509,7 @@ describe('getProfile — timeline dispatch', () => {
     const { getProfile } = await import('../profile.js');
     const result = await getProfile(primitives, { handle: 'hwwaanng', replies: true, count: 5 }) as ProfileWithTimelineResult;
 
-    // Should NOT have intercepted UserTweets pattern
+    // Should NOT have intercepted UserTweets pattern (on either interceptRequest or interceptRequestWithControl)
     const hasUserTweets = interceptedPatterns.some(p => p.includes('UserTweets') && !p.includes('UserTweetsAnd'));
     expect(hasUserTweets).toBe(false);
 

--- a/src/sites/twitter/__tests__/workflows.slow.test.ts
+++ b/src/sites/twitter/__tests__/workflows.slow.test.ts
@@ -21,7 +21,7 @@ function createMockPrimitives(overrides: Partial<Primitives> = {}): Primitives {
     evaluate: vi.fn().mockResolvedValue(undefined),
     screenshot: vi.fn().mockResolvedValue('base64png'),
     interceptRequest: vi.fn().mockResolvedValue(() => {}),
-    interceptRequestWithControl: vi.fn().mockResolvedValue({ cleanup: () => {}, reset: () => {} }),
+    interceptRequestWithControl: vi.fn().mockResolvedValue({ cleanup: () => {}, reset: () => {}, hasPending: () => false }),
     getRawPage: vi.fn().mockResolvedValue({}),
     ...overrides,
   };
@@ -136,6 +136,7 @@ describe('getFeed', () => {
           return {
             cleanup: vi.fn(),
             reset: vi.fn(),
+            hasPending: vi.fn().mockReturnValue(false),
           };
         },
       ),
@@ -217,6 +218,7 @@ describe('getFeed', () => {
           return {
             cleanup: vi.fn(),
             reset: vi.fn(),
+            hasPending: vi.fn().mockReturnValue(false),
           };
         },
       ),
@@ -273,6 +275,7 @@ describe('getFeed', () => {
           return {
             cleanup: vi.fn(),
             reset: vi.fn(),
+            hasPending: vi.fn().mockReturnValue(false),
           };
         },
       ),
@@ -485,25 +488,36 @@ describe('collectData', () => {
     collector.push({ id: '1' }, { id: '2' }, { id: '3' });
 
     const primitives = createMockPrimitives();
-    const result = await collectData(primitives, collector, { count: 2, t0: Date.now() });
+    const result = await collectData(primitives, collector, {
+      count: 2, t0: Date.now(),
+      hasInflightRequest: () => false,
+    });
 
     expect(result.scrollRounds).toBe(0);
-    expect(result.waits).toHaveLength(0);
     expect(primitives.scroll).not.toHaveBeenCalled();
   });
 
   it('scrolls and collects until count reached', async () => {
     const collector = createDataCollector<any>();
     let scrollCount = 0;
+    let pendingRequest = false;
 
     const primitives = createMockPrimitives({
       scroll: vi.fn().mockImplementation(async () => {
         scrollCount++;
-        collector.push({ id: `scroll-${scrollCount}` });
+        pendingRequest = true;
+        setTimeout(() => {
+          pendingRequest = false;
+          collector.push({ id: `scroll-${scrollCount}` });
+        }, 50);
       }),
+      evaluate: vi.fn().mockResolvedValue(false), // not at bottom
     });
 
-    const result = await collectData(primitives, collector, { count: 3, t0: Date.now() });
+    const result = await collectData(primitives, collector, {
+      count: 3, t0: Date.now(),
+      hasInflightRequest: () => pendingRequest,
+    });
 
     expect(collector.length).toBeGreaterThanOrEqual(3);
     expect(result.scrollRounds).toBeGreaterThan(0);
@@ -518,84 +532,146 @@ describe('collectData', () => {
       evaluate: vi.fn().mockResolvedValue(true), // at bottom
     });
 
-    const result = await collectData(primitives, collector, { count: 100, t0: Date.now() });
+    const result = await collectData(primitives, collector, {
+      count: 100, t0: Date.now(),
+      hasInflightRequest: () => false,
+    });
 
-    expect(result.scrollRounds).toBe(3);
-    expect(result.waits.every((w) => !w.satisfied)).toBe(true);
+    // Phase 1 exits immediately (atBottom), stale check runs 3 times
+    expect(result.scrollRounds).toBe(0);
   });
 
-  it('resets staleRounds when new data arrives', { timeout: 15000 }, async () => {
+  it('exits after MAX_PHASE1_SCROLLS * MAX_FAILED_ROUNDS when no request fires', { timeout: 30000 }, async () => {
+    const collector = createDataCollector<any>();
+
+    const primitives = createMockPrimitives({
+      scroll: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockResolvedValue(false), // never at bottom
+    });
+
+    const result = await collectData(primitives, collector, {
+      count: 100, t0: Date.now(),
+      hasInflightRequest: () => false,
+    });
+
+    // Phase 1 scrolls 20 times (MAX_PHASE1_SCROLLS), no request -> Phase 2 timeout
+    // failedRounds=1, forceScroll -> Phase 1 scrolls 20 more -> Phase 2 timeout
+    // failedRounds=2 -> Phase 1 scrolls 20 more -> Phase 2 timeout
+    // failedRounds=3 = MAX_FAILED_ROUNDS -> break
+    expect(result.scrollRounds).toBe(60);
+  });
+
+  it('recovers via forceScroll after Phase 2 timeout', { timeout: 30000 }, async () => {
     const collector = createDataCollector<any>();
     let scrollCount = 0;
+    let pendingRequest = false;
 
     const primitives = createMockPrimitives({
       scroll: vi.fn().mockImplementation(async () => {
         scrollCount++;
-        if (scrollCount === 1 || scrollCount === 3) {
-          collector.push({ id: `s${scrollCount}` });
+        // First batch: no request fires for 20 scrolls -> Phase 2 timeout
+        // Second batch: request fires on scroll 25, data arrives
+        if (scrollCount === 25) {
+          pendingRequest = true;
+          setTimeout(() => {
+            pendingRequest = false;
+            for (let i = 0; i < 100; i++) {
+              collector.push({ id: `item-${i}` });
+            }
+          }, 50);
         }
       }),
-      evaluate: vi.fn().mockResolvedValue(true), // at bottom
+      evaluate: vi.fn().mockResolvedValue(false), // never at bottom
     });
 
-    const result = await collectData(primitives, collector, { count: 100, t0: Date.now() });
+    const result = await collectData(primitives, collector, {
+      count: 50, t0: Date.now(),
+      hasInflightRequest: () => pendingRequest,
+    });
 
-    expect(result.scrollRounds).toBe(6);
+    expect(collector.length).toBeGreaterThanOrEqual(50);
+    expect(result.scrollRounds).toBe(25);
   });
 
-  it('does not count stale rounds while still scrolling to bottom', { timeout: 25000 }, async () => {
+  it('continues scrolling when inflight request never resolves (forceScroll)', { timeout: 15000 }, async () => {
     const collector = createDataCollector<any>();
     let scrollCount = 0;
+    let stuckRequest = false;
 
     const primitives = createMockPrimitives({
-      scroll: vi.fn().mockResolvedValue(undefined),
+      scroll: vi.fn().mockImplementation(async () => {
+        scrollCount++;
+        if (scrollCount === 3) stuckRequest = true;
+      }),
       evaluate: vi.fn().mockImplementation(async () => {
-        scrollCount++;
-        // Not at bottom for first 5 scrolls, then at bottom
-        return scrollCount > 5;
+        return scrollCount >= 10;
       }),
     });
 
-    const result = await collectData(primitives, collector, { count: 100, t0: Date.now() });
-
-    // 5 traversal rounds (not at bottom, no stale increment)
-    // + 3 stale rounds at bottom = 8 total
-    expect(result.scrollRounds).toBe(8);
-  });
-
-  it('exits after MAX_TRAVERSAL_ROUNDS of consecutive traversal', { timeout: 120000 }, async () => {
-    const collector = createDataCollector<any>();
-
-    const primitives = createMockPrimitives({
-      scroll: vi.fn().mockResolvedValue(undefined),
-      evaluate: vi.fn().mockResolvedValue(false), // never at bottom
+    const result = await collectData(primitives, collector, {
+      count: 100, t0: Date.now(),
+      hasInflightRequest: () => stuckRequest,
     });
 
-    const result = await collectData(primitives, collector, { count: 100, t0: Date.now() });
-
-    // Should stop after 40 traversal rounds (MAX_TRAVERSAL_ROUNDS)
-    expect(result.scrollRounds).toBe(40);
+    expect(result.scrollRounds).toBeGreaterThan(0);
   });
 
-  it('resets traversalRounds when new data arrives', { timeout: 150000 }, async () => {
+  it('exits cleanly when responses contain no data', { timeout: 15000 }, async () => {
     const collector = createDataCollector<any>();
     let scrollCount = 0;
+    let pendingRequest = false;
 
     const primitives = createMockPrimitives({
       scroll: vi.fn().mockImplementation(async () => {
         scrollCount++;
-        // Push data on scroll 15 (resets traversal counter mid-way)
-        if (scrollCount === 15) {
-          collector.push({ id: `s${scrollCount}` });
+        if (scrollCount % 3 === 0) {
+          pendingRequest = true;
+          setTimeout(() => {
+            pendingRequest = false;
+            // Push nothing — empty response
+          }, 50);
         }
       }),
-      evaluate: vi.fn().mockResolvedValue(false), // never at bottom
+      evaluate: vi.fn().mockImplementation(async () => scrollCount >= 12),
     });
 
-    const result = await collectData(primitives, collector, { count: 100, t0: Date.now() });
+    const result = await collectData(primitives, collector, {
+      count: 50, t0: Date.now(),
+      hasInflightRequest: () => pendingRequest,
+    });
 
-    // 14 traversal + 1 data (resets) + 40 traversal = 55
-    expect(result.scrollRounds).toBe(55);
+    expect(collector.length).toBe(0);
+    expect(result.scrollRounds).toBeGreaterThan(0);
+  });
+
+  it('handles multiple inflight requests naturally', { timeout: 15000 }, async () => {
+    const collector = createDataCollector<any>();
+    let scrollCount = 0;
+    let pendingRequests = 0;
+
+    const primitives = createMockPrimitives({
+      scroll: vi.fn().mockImplementation(async () => {
+        scrollCount++;
+        if (scrollCount <= 2) {
+          pendingRequests++;
+          const idx = scrollCount;
+          setTimeout(() => {
+            pendingRequests--;
+            collector.push(
+              ...Array.from({ length: 25 }, (_, i) => ({ id: `batch${idx}-${i}` })),
+            );
+          }, 50 * idx);
+        }
+      }),
+      evaluate: vi.fn().mockResolvedValue(false),
+    });
+
+    const result = await collectData(primitives, collector, {
+      count: 50, t0: Date.now(),
+      hasInflightRequest: () => pendingRequests > 0,
+    });
+
+    expect(collector.length).toBeGreaterThanOrEqual(50);
   });
 });
 

--- a/src/sites/twitter/profile.ts
+++ b/src/sites/twitter/profile.ts
@@ -149,8 +149,8 @@ async function getProfileWithTimeline(
       ? createDataCollector<import('./types.js').RawTweetData>()
       : null;
 
-    const cleanupTweets = tweetsCollector
-      ? await primitives.interceptRequest(
+    const tweetsIntercept = tweetsCollector
+      ? await primitives.interceptRequestWithControl(
           GRAPHQL_USER_TWEETS_PATTERN,
           (response) => {
             try {
@@ -159,7 +159,7 @@ async function getProfileWithTimeline(
             } catch { /* non-fatal */ }
           },
         )
-      : () => {};
+      : null;
 
     try {
       await primitives.navigate(`https://x.com/${handle}`);
@@ -210,7 +210,10 @@ async function getProfileWithTimeline(
           // Scroll for more if needed
           const t0 = Date.now();
           if (tweetsCollector.length < count) {
-            await collectData(primitives, tweetsCollector, { count, t0 }, rootSpan);
+            await collectData(primitives, tweetsCollector, {
+              count, t0,
+              hasInflightRequest: tweetsIntercept!.hasPending,
+            }, rootSpan);
           }
 
           const posts = [...tweetsCollector.items]
@@ -244,7 +247,7 @@ async function getProfileWithTimeline(
       return result;
     } finally {
       cleanupProfile();
-      cleanupTweets();
+      tweetsIntercept?.cleanup();
     }
   });
 }
@@ -261,7 +264,7 @@ async function collectReplies(
 ): Promise<FeedItem[]> {
   const repliesCollector = createDataCollector<import('./types.js').RawTweetData>();
 
-  const cleanup = await primitives.interceptRequest(
+  const intercept = await primitives.interceptRequestWithControl(
     GRAPHQL_USER_TWEETS_AND_REPLIES_PATTERN,
     (response) => {
       try {
@@ -334,7 +337,10 @@ async function collectReplies(
 
     while (true) {
       if (repliesCollector.length < rawTarget) {
-        await collectData(primitives, repliesCollector, { count: rawTarget, t0 }, span);
+        await collectData(primitives, repliesCollector, {
+          count: rawTarget, t0,
+          hasInflightRequest: intercept.hasPending,
+        }, span);
       }
 
       // Check: enough target-user replies in raw data?
@@ -381,6 +387,6 @@ async function collectReplies(
     span.set('repliesReturned', feedItems.length);
     return feedItems;
   } finally {
-    cleanup();
+    intercept.cleanup();
   }
 }

--- a/src/sites/twitter/workflows.ts
+++ b/src/sites/twitter/workflows.ts
@@ -235,7 +235,7 @@ export async function getSearch(
     const collector = createDataCollector<RawTweetData>();
     let dumpIndex = 0;
 
-    const cleanup = await primitives.interceptRequest(
+    const intercept = await primitives.interceptRequestWithControl(
       GRAPHQL_SEARCH_PATTERN,
       (response) => {
         try {
@@ -262,7 +262,10 @@ export async function getSearch(
 
       if (collector.length < count) {
         await rootSpan.span('collectData', async (s) => {
-          await collectData(primitives, collector, { count, t0 }, s);
+          await collectData(primitives, collector, {
+            count, t0,
+            hasInflightRequest: intercept.hasPending,
+          }, s);
         });
       }
 
@@ -289,83 +292,122 @@ export async function getSearch(
         },
       };
     } finally {
-      cleanup();
+      intercept.cleanup();
     }
   });
 }
 
 const MAX_STALE_ROUNDS = 3;
-const MAX_TRAVERSAL_ROUNDS = 40;
+const MAX_PHASE1_SCROLLS = 20;
+const MAX_FAILED_ROUNDS = 3;
 const SCROLL_WAIT_MS = 2000;
+const PHASE1_PAUSE_MIN_MS = 50;
+const PHASE1_PAUSE_MAX_MS = 150;
+const BOTTOM_WAIT_MS = 500;
 
 /**
  * Scroll timeline and collect data until count is reached or no more data arrives.
+ *
+ * Two-phase design:
+ * - Phase 1: fast scroll until a matching API request fires or page bottom reached
+ * - Phase 2: request is in-flight, wait for response data to arrive in collector
  */
 export async function collectData(
   primitives: Primitives,
   collector: DataCollector<RawTweetData>,
-  opts: { count: number; t0: number },
+  opts: { count: number; t0: number; hasInflightRequest: () => boolean },
   span: SpanHandle = NOOP_SPAN,
 ): Promise<CollectDataResult> {
-  const { count, t0 } = opts;
-  const waits: Array<WaitRecord & { round: number }> = [];
+  const { count, t0, hasInflightRequest } = opts;
 
   // Fast path: already have enough data
   if (collector.length >= count) {
     console.error(`[site-use] already have ${collector.length}/${count} items, skipping scroll`);
-    return { scrollRounds: 0, waits };
+    return { scrollRounds: 0, waits: [] };
   }
 
   console.error(`[site-use] scrolling to collect ${count} items...`);
   let staleRounds = 0;
-  let traversalRounds = 0;
-  let round = 0;
+  let failedRounds = 0;
+  let forceScroll = false;
+  let totalScrolls = 0;
 
-  while (staleRounds < MAX_STALE_ROUNDS && traversalRounds < MAX_TRAVERSAL_ROUNDS) {
-    if (collector.length >= count) break;
+  const checkAtBottom = () =>
+    primitives.evaluate<boolean>(
+      `window.scrollY + document.documentElement.clientHeight >= document.documentElement.scrollHeight - 200`,
+    );
 
-    round++;
+  while (collector.length < count) {
     const prevTotal = collector.length;
 
-    await span.span(`scroll_${round}`, async (s) => {
-      await primitives.scroll({ direction: 'down' });
+    // Phase 1: fast scroll until request fires or at bottom
+    let phase1Scrolls = 0;
+    await span.span(`phase1_${totalScrolls}`, async (s) => {
+      while (phase1Scrolls < MAX_PHASE1_SCROLLS) {
+        const atBottom = await checkAtBottom();
+        if (atBottom) {
+          s.set('exitReason', 'atBottom');
+          break;
+        }
+        if (!forceScroll && hasInflightRequest()) {
+          s.set('exitReason', 'requestFired');
+          break;
+        }
+        forceScroll = false;
 
+        await primitives.scroll({ direction: 'down', amount: 1200 });
+        phase1Scrolls++;
+        totalScrolls++;
+
+        const pause = PHASE1_PAUSE_MIN_MS + Math.random() * (PHASE1_PAUSE_MAX_MS - PHASE1_PAUSE_MIN_MS);
+        await new Promise((r) => setTimeout(r, pause));
+      }
+      if (phase1Scrolls >= MAX_PHASE1_SCROLLS) {
+        s.set('exitReason', 'maxScrolls');
+      }
+      s.set('scrolls', phase1Scrolls);
+    });
+    forceScroll = false;
+
+    // Stale check: at bottom with no pending request
+    const atBottom = await checkAtBottom();
+    if (atBottom && !hasInflightRequest()) {
+      await new Promise((r) => setTimeout(r, BOTTOM_WAIT_MS));
+      if (hasInflightRequest()) {
+        console.error(`[site-use] request fired during bottom wait, continuing`);
+        continue;
+      }
+      staleRounds++;
+      console.error(`[site-use] at bottom, no request (stale ${staleRounds}/${MAX_STALE_ROUNDS})`);
+      if (staleRounds >= MAX_STALE_ROUNDS) break;
+      continue;
+    }
+
+    // Phase 2: request is out, wait for data
+    staleRounds = 0;
+    const satisfied = await span.span(`phase2_${totalScrolls}`, async (s) => {
       const startedAt = Date.now() - t0;
-      const satisfied = await collector.waitUntil(() => collector.length > prevTotal, SCROLL_WAIT_MS);
-      waits.push({
-        round,
-        purpose: `scroll_${round}`,
-        startedAt,
-        resolvedAt: Date.now() - t0,
-        satisfied,
-        dataCount: collector.length,
-      });
-
-      s.set('satisfied', satisfied);
+      const ok = await collector.waitUntil(() => collector.length > prevTotal, SCROLL_WAIT_MS);
+      s.set('satisfied', ok);
+      s.set('startedAt', startedAt);
+      s.set('resolvedAt', Date.now() - t0);
       s.set('dataCount', collector.length);
       s.set('newItems', collector.length - prevTotal);
-
-      if (satisfied) {
-        staleRounds = 0;
-        traversalRounds = 0;
-        console.error(`[site-use] scroll ${round}: collected ${collector.length}/${count} items`);
-      } else {
-        const atBottom = await primitives.evaluate<boolean>(
-          `window.scrollY + document.documentElement.clientHeight >= document.documentElement.scrollHeight - 200`,
-        );
-        if (atBottom) {
-          staleRounds++;
-          traversalRounds = 0;
-          console.error(`[site-use] scroll ${round}: no new data at bottom (stale ${staleRounds}/${MAX_STALE_ROUNDS})`);
-        } else {
-          traversalRounds++;
-          console.error(`[site-use] scroll ${round}: no new data yet, still scrolling (${traversalRounds}/${MAX_TRAVERSAL_ROUNDS})`);
-        }
-      }
+      return ok;
     });
+
+    if (satisfied) {
+      failedRounds = 0;
+      console.error(`[site-use] collected ${collector.length}/${count} items`);
+    } else {
+      failedRounds++;
+      forceScroll = true;
+      console.error(`[site-use] phase2 timeout (failed ${failedRounds}/${MAX_FAILED_ROUNDS})`);
+      if (failedRounds >= MAX_FAILED_ROUNDS) break;
+    }
   }
 
-  return { scrollRounds: round, waits };
+  return { scrollRounds: totalScrolls, waits: [] };
 }
 
 export async function getFeed(
@@ -427,7 +469,10 @@ export async function getFeed(
       });
 
       await rootSpan.span('collectData', async (s) => {
-        await collectData(primitives, collector, { count, t0 }, s);
+        await collectData(primitives, collector, {
+          count, t0,
+          hasInflightRequest: intercept.hasPending,
+        }, s);
       });
 
       const tweets = [...collector.items]
@@ -490,7 +535,7 @@ export async function getTweetDetail(
     const collector = createDataCollector<RawTweetData>();
     let dumpIndex = 0;
 
-    const cleanup = await primitives.interceptRequest(
+    const intercept = await primitives.interceptRequestWithControl(
       GRAPHQL_TWEET_DETAIL_PATTERN,
       (response) => {
         try {
@@ -524,7 +569,10 @@ export async function getTweetDetail(
 
       if (collector.length < count && hasCursor) {
         await rootSpan.span('collectData', async (s) => {
-          await collectData(primitives, collector, { count, t0 }, s);
+          await collectData(primitives, collector, {
+            count, t0,
+            hasInflightRequest: intercept.hasPending,
+          }, s);
         });
       }
 
@@ -559,7 +607,7 @@ export async function getTweetDetail(
         },
       };
     } finally {
-      cleanup();
+      intercept.cleanup();
     }
   });
 }

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -17,7 +17,7 @@ export function createMockPrimitives(overrides: Partial<Primitives> = {}): Primi
     evaluate: vi.fn(async () => undefined as never),
     screenshot: vi.fn(async () => ''),
     interceptRequest: vi.fn(async () => () => {}),
-    interceptRequestWithControl: vi.fn(async () => ({ cleanup: () => {}, reset: () => {} })),
+    interceptRequestWithControl: vi.fn(async () => ({ cleanup: () => {}, reset: () => {}, hasPending: () => false })),
     getRawPage: vi.fn(async () => ({}) as never),
     ...overrides,
   };

--- a/tests/unit/intercept-race.test.ts
+++ b/tests/unit/intercept-race.test.ts
@@ -70,7 +70,7 @@ function interceptSchemeI(
   page: MockPage,
   urlPattern: RegExp,
   handler: InterceptHandler,
-): InterceptControl {
+): InterceptControl & { hasPending: () => boolean } {
   let validRequests = new Set<object>();
 
   const requestListener = (request: any) => {
@@ -79,10 +79,16 @@ function interceptSchemeI(
 
   const responseListener = async (response: any) => {
     if (!urlPattern.test(response.url())) return;
-    const body = await response.text();
-    // Check AFTER await
-    if (!validRequests.has(response.request())) return;
-    handler({ url: response.url(), status: response.status(), body });
+    try {
+      const body = await response.text();
+      // Check AFTER await
+      const req = response.request();
+      if (!validRequests.has(req)) return;
+      validRequests.delete(req);
+      handler({ url: response.url(), status: response.status(), body });
+    } catch {
+      validRequests.delete(response.request());
+    }
   };
 
   page.on('request', requestListener);
@@ -94,6 +100,7 @@ function interceptSchemeI(
       page.off('response', responseListener);
     },
     reset: () => { validRequests = new Set(); },
+    hasPending: () => validRequests.size > 0,
   };
 }
 
@@ -238,5 +245,53 @@ describe('Path Y: response event fires AFTER handler swap / reset', () => {
     // Path X: listener entered before reset, but body resolved after.
     // Check is AFTER await → R1 request not in new Set → rejected
     expect(collected).toHaveLength(0);
+  });
+});
+
+describe('hasPending: tracks in-flight requests', () => {
+
+  it('returns false when no requests are tracked', () => {
+    const page = new MockPage();
+    const intercept = interceptSchemeI(page, TIMELINE_PATTERN, () => {});
+    expect(intercept.hasPending()).toBe(false);
+  });
+
+  it('returns true after request fires, false after response resolves', async () => {
+    const page = new MockPage();
+    const intercept = interceptSchemeI(page, TIMELINE_PATTERN, () => {});
+
+    const req = { url: () => '/i/api/graphql/xyz/HomeTimeline' };
+    page.emitRequest(req);
+    expect(intercept.hasPending()).toBe(true);
+
+    page.emitResponse(makeResponse(req, '/i/api/graphql/xyz/HomeTimeline', 'data'));
+    await new Promise(r => setTimeout(r, 10));
+
+    expect(intercept.hasPending()).toBe(false);
+  });
+
+  it('clears pending when response.text() throws', async () => {
+    const page = new MockPage();
+    const collected: string[] = [];
+    const intercept = interceptSchemeI(page, TIMELINE_PATTERN, (r) => {
+      collected.push(r.body);
+    });
+
+    const req = { url: () => '/i/api/graphql/xyz/HomeTimeline' };
+    page.emitRequest(req);
+    expect(intercept.hasPending()).toBe(true);
+
+    // Emit response whose text() rejects (e.g., redirect or consumed body)
+    page.emitResponse({
+      request: () => req,
+      url: () => '/i/api/graphql/xyz/HomeTimeline',
+      status: () => 302,
+      text: () => Promise.reject(new Error('Response body is unavailable')),
+    });
+    await new Promise(r => setTimeout(r, 10));
+
+    // Must clear: handler should NOT be called, and hasPending must return false
+    expect(collected).toHaveLength(0);
+    expect(intercept.hasPending()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Replace collectData's blind scroll-then-wait loop with a two-phase design: Phase 1 fast-scrolls until a matching API request fires or page bottom is reached, Phase 2 waits for response data (2s timeout)
- Add `hasPending()` to `InterceptControl` interface for request detection; switch all callers from `interceptRequest` to `interceptRequestWithControl`
- Remove scroll/scrollIntoView from throttle layer (humanScroll internals already provide humanization via bell curve, jitter, step delays)
- Increase scroll amount to 1200px with jittered inter-scroll pause (50-150ms) for natural rhythm

Search for 50 results: ~120s timeout -> ~15s.

## Test plan

- [x] Unit tests: 376 passing (baseline preserved)
- [x] search --count 50: completes in ~15s
- [x] search --count 5: fast path, no scroll
- [x] feed --count 50: scrolls and collects correctly
- [x] feed --count 5: fast path
- [x] tweet_detail --count 50: collects replies
- [x] profile --posts --count 50: scrolls and collects
- [x] profile --replies --count 50: multi-round raw collection + filter
- [x] follow-list --count 50: independent scroll loop, no regression