### PR TITLE
feat: iframe pipeline M1 — 5-stage takeSnapshot with same-origin iframe support

### DIFF
--- a/packages/runtime/src/internal/primitives/puppeteer-backend.ts
+++ b/packages/runtime/src/internal/primitives/puppeteer-backend.ts
@@ -20,11 +20,15 @@ import {
 import type {
   Primitives,
   Snapshot,
-  SnapshotNode,
   ScrollOptions,
   InterceptHandler,
   InterceptControl,
 } from './types.js';
+import { fetchAXData } from './snapshot/fetch.js';
+import { hydrateAXData } from './snapshot/hydrate.js';
+import { mergeAXData } from './snapshot/merge.js';
+import { filterNodes } from './snapshot/filter.js';
+import { buildSnapshotOutput } from './snapshot/output.js';
 import { RateLimitDetector } from './rate-limit-detect.js';
 
 const DEFAULT_SITE = '_default';
@@ -409,103 +413,20 @@ export class PuppeteerBackend implements Primitives {
     const client = await page.createCDPSession();
 
     try {
-      const { nodes } = await client.send('Accessibility.getFullAXTree');
-      return this.buildSnapshot(nodes);
+      // 5-stage pipeline: fetch → hydrate → merge → filter → output
+      const rawData = await fetchAXData(client);
+      const hydrated = hydrateAXData(rawData);
+      const { nodes, uidToBackendNodeId, axIdToUid } = mergeAXData(hydrated);
+      const filtered = filterNodes(nodes);
+      // TODO(M2): When filter becomes non-trivial, recompute uidToBackendNodeId and
+      // axIdToUid from `filtered` to avoid dangling children refs and stale click targets.
+      const snapshot = buildSnapshotOutput(filtered, axIdToUid);
+
+      this.uidToBackendNodeId = uidToBackendNodeId;
+      return snapshot;
     } finally {
       await client.detach();
     }
-  }
-
-  private buildSnapshot(axNodes: any[]): Snapshot {
-    const idToNode = new Map<string, SnapshotNode>();
-    this.uidToBackendNodeId = new Map();
-
-    // Build nodeId -> axNode lookup for parent-child resolution
-    const axNodeById = new Map<string, any>();
-    for (const node of axNodes) {
-      axNodeById.set(node.nodeId, node);
-    }
-
-    let nextUid = 1;
-
-    // Map from AX nodeId to assigned uid (for child reference resolution)
-    const axIdToUid = new Map<string, string>();
-
-    // First pass: assign uids to valid nodes
-    for (const node of axNodes) {
-      if (this.shouldSkipNode(node)) continue;
-
-      const uid = String(nextUid++);
-      axIdToUid.set(node.nodeId, uid);
-
-      if (node.backendDOMNodeId != null) {
-        this.uidToBackendNodeId.set(uid, node.backendDOMNodeId);
-      }
-    }
-
-    // Second pass: build SnapshotNode objects with children
-    for (const node of axNodes) {
-      const uid = axIdToUid.get(node.nodeId);
-      if (!uid) continue;
-
-      const snapshotNode: SnapshotNode = {
-        uid,
-        role: node.role?.value ?? '',
-        name: node.name?.value ?? '',
-      };
-
-      // Optional properties from AX properties array
-      if (node.properties) {
-        for (const prop of node.properties) {
-          const val = prop.value?.value;
-          switch (prop.name) {
-            case 'focused':
-              if (val) snapshotNode.focused = true;
-              break;
-            case 'disabled':
-              if (val) snapshotNode.disabled = true;
-              break;
-            case 'expanded':
-              if (val != null) snapshotNode.expanded = val;
-              break;
-            case 'selected':
-              if (val) snapshotNode.selected = true;
-              break;
-            case 'level':
-              if (val != null) snapshotNode.level = val;
-              break;
-          }
-        }
-      }
-
-      // Value (for form elements)
-      if (node.value?.value != null) {
-        snapshotNode.value = String(node.value.value);
-      }
-
-      // Children (resolve AX childIds to assigned uids)
-      if (node.childIds?.length) {
-        const childUids: string[] = [];
-        for (const childId of node.childIds) {
-          const childUid = axIdToUid.get(childId);
-          if (childUid) childUids.push(childUid);
-        }
-        if (childUids.length > 0) {
-          snapshotNode.children = childUids;
-        }
-      }
-
-      idToNode.set(uid, snapshotNode);
-    }
-
-    return { idToNode };
-  }
-
-  private shouldSkipNode(node: any): boolean {
-    if (node.ignored) return true;
-    const role = node.role?.value;
-    if (role === 'none' || role === 'Ignored') return true;
-    return false;
   }
 
   /**

--- a/packages/runtime/src/internal/primitives/snapshot/fetch.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/fetch.ts
@@ -1,0 +1,46 @@
+import type { RawFrameAX } from './types.js';
+import { MAX_IFRAME_DEPTH, MAX_IFRAMES } from './types.js';
+
+/**
+ * Fetch AX tree data from all same-origin frames.
+ * Traverses Page.getFrameTree, skips cross-origin iframes (OOPIF),
+ * enforces depth and count limits.
+ */
+export async function fetchAXData(client: any): Promise<RawFrameAX[]> {
+  // Graceful degradation: if Page.getFrameTree is unavailable (Chrome <120),
+  // fall back to the original single-frame behavior.
+  let frameTree: any;
+  try {
+    ({ frameTree } = await client.send('Page.getFrameTree'));
+  } catch {
+    const { nodes } = await client.send('Accessibility.getFullAXTree');
+    return [{ frameId: '', frameUrl: '', isMainFrame: true, nodes }];
+  }
+
+  const mainOrigin = frameTree.frame.securityOrigin;
+  const mainFrameId = frameTree.frame.id;
+
+  const frames: Array<{ id: string; url: string; isMainFrame: boolean }> = [];
+
+  function walk(node: any, depth: number): void {
+    frames.push({ id: node.frame.id, url: node.frame.url, isMainFrame: node.frame.id === mainFrameId });
+    if (depth >= MAX_IFRAME_DEPTH) return;
+    for (const child of node.childFrames ?? []) {
+      if (frames.length >= MAX_IFRAMES) break;
+      if (child.frame.securityOrigin !== mainOrigin) continue;
+      walk(child, depth + 1);
+    }
+  }
+  walk(frameTree, 0);
+
+  const results = await Promise.allSettled(
+    frames.map(async (f): Promise<RawFrameAX> => {
+      const { nodes } = await client.send('Accessibility.getFullAXTree', { frameId: f.id });
+      return { frameId: f.id, frameUrl: f.url, isMainFrame: f.isMainFrame, nodes };
+    }),
+  );
+
+  return results
+    .filter((r): r is PromiseFulfilledResult<RawFrameAX> => r.status === 'fulfilled')
+    .map(r => r.value);
+}

--- a/packages/runtime/src/internal/primitives/snapshot/filter.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/filter.ts
@@ -1,0 +1,11 @@
+import type { MergedNode } from './types.js';
+
+/**
+ * Filter merged nodes.
+ * M1: passthrough — no additional filtering beyond shouldSkipNode in merge.
+ * Future (M2): ClickableElementDetector
+ * Future (M4): PaintOrderRemover, bbox filter, simplify, optimize
+ */
+export function filterNodes(nodes: MergedNode[]): MergedNode[] {
+  return nodes;
+}

--- a/packages/runtime/src/internal/primitives/snapshot/hydrate.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/hydrate.ts
@@ -1,0 +1,11 @@
+import type { RawFrameAX } from './types.js';
+
+/**
+ * Hydrate raw CDP data into usable lookup structures.
+ * M1: passthrough — AX data is already in usable format.
+ * Future (M2): DOMSnapshot SoA → per-node lookup.
+ * Future (M3): DOM tree → backendNodeId lookup.
+ */
+export function hydrateAXData(rawData: RawFrameAX[]): RawFrameAX[] {
+  return rawData;
+}

--- a/packages/runtime/src/internal/primitives/snapshot/index.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/index.ts
@@ -1,0 +1,7 @@
+export { fetchAXData } from './fetch.js';
+export { hydrateAXData } from './hydrate.js';
+export { mergeAXData, type MergeResult } from './merge.js';
+export { filterNodes } from './filter.js';
+export { buildSnapshotOutput } from './output.js';
+export type { RawFrameAX, MergedNode } from './types.js';
+export { MAX_IFRAME_DEPTH, MAX_IFRAMES } from './types.js';

--- a/packages/runtime/src/internal/primitives/snapshot/merge.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/merge.ts
@@ -1,0 +1,51 @@
+import type { RawFrameAX, MergedNode } from './types.js';
+
+export interface MergeResult {
+  nodes: MergedNode[];
+  uidToBackendNodeId: Map<string, number>;
+  axIdToUid: Map<string, string>;
+}
+
+function shouldSkipNode(node: any): boolean {
+  if (node.ignored) return true;
+  const role = node.role?.value;
+  if (role === 'none' || role === 'Ignored') return true;
+  return false;
+}
+
+/**
+ * Merge multi-frame AX data into a flat list of MergedNodes.
+ * Assigns sequential uids, populates uidToBackendNodeId, filters ignored nodes.
+ * First frame in the array is treated as the main frame (frameUrl = undefined).
+ */
+export function mergeAXData(rawData: RawFrameAX[]): MergeResult {
+  const nodes: MergedNode[] = [];
+  const uidToBackendNodeId = new Map<string, number>();
+  const axIdToUid = new Map<string, string>();
+  let nextUid = 1;
+
+  for (const frame of rawData) {
+    for (const axNode of frame.nodes) {
+      if (shouldSkipNode(axNode)) continue;
+
+      const uid = String(nextUid++);
+      // Scope by frameId to prevent cross-frame nodeId collisions.
+      // CDP does not guarantee globally unique AX nodeIds across frames.
+      axIdToUid.set(`${frame.frameId}:${axNode.nodeId}`, uid);
+
+      if (axNode.backendDOMNodeId != null) {
+        uidToBackendNodeId.set(uid, axNode.backendDOMNodeId);
+      }
+
+      nodes.push({
+        uid,
+        axNode,
+        backendNodeId: axNode.backendDOMNodeId ?? null,
+        frameId: frame.frameId,
+        frameUrl: frame.isMainFrame ? undefined : frame.frameUrl,
+      });
+    }
+  }
+
+  return { nodes, uidToBackendNodeId, axIdToUid };
+}

--- a/packages/runtime/src/internal/primitives/snapshot/output.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/output.ts
@@ -1,0 +1,73 @@
+import type { Snapshot, SnapshotNode } from '../types.js';
+import type { MergedNode } from './types.js';
+
+/**
+ * Build the final Snapshot from merged nodes.
+ * Extracts AX properties, resolves children, sets frameUrl.
+ */
+export function buildSnapshotOutput(
+  nodes: MergedNode[],
+  axIdToUid: Map<string, string>,
+): Snapshot {
+  const idToNode = new Map<string, SnapshotNode>();
+
+  for (const merged of nodes) {
+    const { axNode } = merged;
+
+    const snapshotNode: SnapshotNode = {
+      uid: merged.uid,
+      role: axNode.role?.value ?? '',
+      name: axNode.name?.value ?? '',
+    };
+
+    // frameUrl (only for iframe nodes)
+    if (merged.frameUrl != null) {
+      snapshotNode.frameUrl = merged.frameUrl;
+    }
+
+    // Optional AX properties
+    if (axNode.properties) {
+      for (const prop of axNode.properties) {
+        const val = prop.value?.value;
+        switch (prop.name) {
+          case 'focused':
+            if (val) snapshotNode.focused = true;
+            break;
+          case 'disabled':
+            if (val) snapshotNode.disabled = true;
+            break;
+          case 'expanded':
+            if (val != null) snapshotNode.expanded = val;
+            break;
+          case 'selected':
+            if (val) snapshotNode.selected = true;
+            break;
+          case 'level':
+            if (val != null) snapshotNode.level = val;
+            break;
+        }
+      }
+    }
+
+    // Value (form elements)
+    if (axNode.value?.value != null) {
+      snapshotNode.value = String(axNode.value.value);
+    }
+
+    // Children (resolve AX childIds to assigned uids, scoped by frameId)
+    if (axNode.childIds?.length) {
+      const childUids: string[] = [];
+      for (const childId of axNode.childIds) {
+        const childUid = axIdToUid.get(`${merged.frameId}:${childId}`);
+        if (childUid) childUids.push(childUid);
+      }
+      if (childUids.length > 0) {
+        snapshotNode.children = childUids;
+      }
+    }
+
+    idToNode.set(merged.uid, snapshotNode);
+  }
+
+  return { idToNode };
+}

--- a/packages/runtime/src/internal/primitives/snapshot/types.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/types.ts
@@ -1,0 +1,20 @@
+/** Raw AX data from a single frame, returned by fetch stage. */
+export interface RawFrameAX {
+  frameId: string;
+  frameUrl: string;
+  isMainFrame: boolean;
+  nodes: any[]; // CDP Protocol.Accessibility.AXNode[]
+}
+
+/** Node after merge stage — ready for filtering and output. */
+export interface MergedNode {
+  uid: string;
+  axNode: any; // Original CDP AXNode
+  backendNodeId: number | null;
+  frameId: string; // frame that owns this node (for scoped child lookup)
+  frameUrl: string | undefined; // undefined for main frame
+}
+
+/** Limits for iframe traversal to defend against malicious pages. */
+export const MAX_IFRAME_DEPTH = 5;
+export const MAX_IFRAMES = 100;

--- a/packages/runtime/src/internal/primitives/types.ts
+++ b/packages/runtime/src/internal/primitives/types.ts
@@ -15,6 +15,8 @@ export interface SnapshotNode {
   expanded?: boolean;
   selected?: boolean;
   level?: number;
+  /** URL of the containing frame. Only set for iframe nodes; undefined for main frame. */
+  frameUrl?: string;
 }
 
 export interface Snapshot {

--- a/src/ops/hover.ts
+++ b/src/ops/hover.ts
@@ -1,0 +1,38 @@
+import type { Primitives } from '../primitives/types.js';
+
+/**
+ * Move the mouse to the center of an element identified by CSS selector.
+ * Triggers mouseenter/mouseover events for hover-to-reveal UI patterns.
+ *
+ * Uses evaluate() for coordinates and CDP Input.dispatchMouseEvent for movement.
+ * Only for main-frame elements — iframe elements should use backendNodeId path.
+ */
+export async function hover(primitives: Primitives, selector: string): Promise<void> {
+  const rect = await primitives.evaluate<{ x: number; y: number; w: number; h: number } | null>(
+    `(() => {
+      const el = document.querySelector(${JSON.stringify(selector)});
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return { x: r.x, y: r.y, w: r.width, h: r.height };
+    })()`,
+  );
+
+  // Reject sub-pixel elements (< 1 CSS pixel) — they are effectively invisible
+  // and cannot be meaningfully hovered. This catches display:none (0×0) and
+  // fractional-pixel elements from CSS transforms.
+  if (!rect || rect.w < 1 || rect.h < 1) {
+    throw new Error(`hover: element not found or zero-size for selector "${selector}"`);
+  }
+
+  const page = await primitives.getRawPage();
+  const cdp = await page.createCDPSession();
+  try {
+    await cdp.send('Input.dispatchMouseEvent', {
+      type: 'mouseMoved',
+      x: rect.x + rect.w / 2,
+      y: rect.y + rect.h / 2,
+    });
+  } finally {
+    await cdp.detach();
+  }
+}

--- a/src/ops/index.ts
+++ b/src/ops/index.ts
@@ -1,3 +1,4 @@
 export { matchByRule, matchAllByRule, type MatcherRule as MatchRule } from './matchers.js';
 export { makeEnsureState } from './ensure-state.js';
 export { createDataCollector, type DataCollector } from './data-collector.js';
+export { hover } from './hover.js';

--- a/tests/unit/hover.test.ts
+++ b/tests/unit/hover.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { hover } from '../../src/ops/hover.js';
+
+function mockPrimitives(rect: { x: number; y: number; w: number; h: number } | null) {
+  const sendFn = vi.fn().mockResolvedValue(undefined);
+  const detachFn = vi.fn().mockResolvedValue(undefined);
+
+  return {
+    primitives: {
+      evaluate: vi.fn().mockResolvedValue(rect),
+      getRawPage: vi.fn().mockResolvedValue({
+        createCDPSession: vi.fn().mockResolvedValue({
+          send: sendFn,
+          detach: detachFn,
+        }),
+      }),
+    },
+    sendFn,
+    detachFn,
+  };
+}
+
+describe('hover', () => {
+  it('dispatches mouseMoved to element center', async () => {
+    const { primitives, sendFn } = mockPrimitives({ x: 100, y: 200, w: 50, h: 30 });
+
+    await hover(primitives as any, '.card');
+
+    expect(sendFn).toHaveBeenCalledWith('Input.dispatchMouseEvent', {
+      type: 'mouseMoved',
+      x: 125,
+      y: 215,
+    });
+  });
+
+  it('throws when element is not found', async () => {
+    const { primitives } = mockPrimitives(null);
+
+    await expect(hover(primitives as any, '.missing')).rejects.toThrow(/not found/);
+  });
+
+  it('throws when element has zero size', async () => {
+    const { primitives } = mockPrimitives({ x: 10, y: 10, w: 0, h: 0 });
+
+    await expect(hover(primitives as any, '.hidden')).rejects.toThrow(/not found|zero/);
+  });
+
+  it('detaches CDP session after use', async () => {
+    const { primitives, detachFn } = mockPrimitives({ x: 0, y: 0, w: 100, h: 100 });
+
+    await hover(primitives as any, '.card');
+
+    expect(detachFn).toHaveBeenCalled();
+  });
+
+  it('detaches CDP session even on error', async () => {
+    const detachFn = vi.fn().mockResolvedValue(undefined);
+    const primitives = {
+      evaluate: vi.fn().mockResolvedValue({ x: 0, y: 0, w: 100, h: 100 }),
+      getRawPage: vi.fn().mockResolvedValue({
+        createCDPSession: vi.fn().mockResolvedValue({
+          send: vi.fn().mockRejectedValue(new Error('CDP error')),
+          detach: detachFn,
+        }),
+      }),
+    };
+
+    await expect(hover(primitives as any, '.card')).rejects.toThrow('CDP error');
+    expect(detachFn).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/puppeteer-backend.test.ts
+++ b/tests/unit/puppeteer-backend.test.ts
@@ -129,6 +129,7 @@ describe('PuppeteerBackend', () => {
     function createWindowStateMock(windowState: string) {
       return {
         send: vi.fn().mockImplementation((method: string) => {
+          if (method === 'Page.getFrameTree') return Promise.resolve({ frameTree: { frame: { id: 'main', url: 'https://example.com', securityOrigin: 'https://example.com' } } });
           if (method === 'Browser.getWindowForTarget') return Promise.resolve({ windowId: 1 });
           if (method === 'Browser.getWindowBounds') return Promise.resolve({ bounds: { windowState } });
           if (method === 'Accessibility.getFullAXTree') {
@@ -311,7 +312,14 @@ describe('PuppeteerBackend', () => {
     // Helper: build a mock CDP session that returns a fake AX tree
     function mockCDPSessionWithAXTree(nodes: any[]) {
       const session = {
-        send: vi.fn().mockImplementation((method: string) => {
+        send: vi.fn().mockImplementation((method: string, params?: any) => {
+          if (method === 'Page.getFrameTree') {
+            return Promise.resolve({
+              frameTree: {
+                frame: { id: 'main', url: 'https://example.com', securityOrigin: 'https://example.com' },
+              },
+            });
+          }
           if (method === 'Accessibility.getFullAXTree') {
             return Promise.resolve({ nodes });
           }
@@ -478,6 +486,7 @@ describe('PuppeteerBackend', () => {
     function setupClickMocks() {
       const session = {
         send: vi.fn().mockImplementation((method: string, _params?: any) => {
+          if (method === 'Page.getFrameTree') return Promise.resolve({ frameTree: { frame: { id: 'main', url: 'https://example.com', securityOrigin: 'https://example.com' } } });
           if (method === 'Accessibility.getFullAXTree') {
             return Promise.resolve({
               nodes: [
@@ -557,6 +566,7 @@ describe('PuppeteerBackend', () => {
 
       const cdpSession = {
         send: vi.fn().mockImplementation((method: string) => {
+          if (method === 'Page.getFrameTree') return Promise.resolve({ frameTree: { frame: { id: 'main', url: 'https://example.com', securityOrigin: 'https://example.com' } } });
           if (method === 'Accessibility.getFullAXTree') {
             return Promise.resolve({ nodes: [{ nodeId: 'ax-1', role: { value: 'button' }, name: { value: 'Follow' }, backendDOMNodeId: 101, ignored: false, properties: [] }] });
           }
@@ -597,6 +607,7 @@ describe('PuppeteerBackend', () => {
 
       const cdpSession = {
         send: vi.fn().mockImplementation((method: string) => {
+          if (method === 'Page.getFrameTree') return Promise.resolve({ frameTree: { frame: { id: 'main', url: 'https://example.com', securityOrigin: 'https://example.com' } } });
           if (method === 'Accessibility.getFullAXTree') {
             return Promise.resolve({ nodes: [{ nodeId: 'ax-1', role: { value: 'button' }, name: { value: 'Follow' }, backendDOMNodeId: 101, ignored: false, properties: [] }] });
           }
@@ -634,6 +645,7 @@ describe('PuppeteerBackend', () => {
 
       const cdpSession = {
         send: vi.fn().mockImplementation((method: string) => {
+          if (method === 'Page.getFrameTree') return Promise.resolve({ frameTree: { frame: { id: 'main', url: 'https://example.com', securityOrigin: 'https://example.com' } } });
           if (method === 'Browser.getWindowForTarget') return Promise.resolve({ windowId: 1 });
           if (method === 'Browser.setWindowBounds') return Promise.resolve({});
           if (method === 'Accessibility.getFullAXTree') {
@@ -676,6 +688,7 @@ describe('PuppeteerBackend', () => {
       let pageVisible = false;
       const cdpSession = {
         send: vi.fn().mockImplementation((method: string, params?: any) => {
+          if (method === 'Page.getFrameTree') return Promise.resolve({ frameTree: { frame: { id: 'main', url: 'https://example.com', securityOrigin: 'https://example.com' } } });
           if (method === 'Accessibility.getFullAXTree') {
             return Promise.resolve({ nodes: [{ nodeId: 'ax-1', role: { value: 'button' }, name: { value: 'Follow' }, backendDOMNodeId: 101, ignored: false, properties: [] }] });
           }
@@ -732,6 +745,7 @@ describe('PuppeteerBackend', () => {
 
       const cdpSession = {
         send: vi.fn().mockImplementation((method: string) => {
+          if (method === 'Page.getFrameTree') return Promise.resolve({ frameTree: { frame: { id: 'main', url: 'https://example.com', securityOrigin: 'https://example.com' } } });
           if (method === 'Accessibility.getFullAXTree') {
             return Promise.resolve({ nodes: [{ nodeId: 'ax-1', role: { value: 'button' }, name: { value: 'Follow' }, backendDOMNodeId: 101, ignored: false, properties: [] }] });
           }
@@ -770,6 +784,7 @@ describe('PuppeteerBackend', () => {
 
       const cdpSession = {
         send: vi.fn().mockImplementation((method: string) => {
+          if (method === 'Page.getFrameTree') return Promise.resolve({ frameTree: { frame: { id: 'main', url: 'https://example.com', securityOrigin: 'https://example.com' } } });
           if (method === 'Accessibility.getFullAXTree') {
             return Promise.resolve({ nodes: [{ nodeId: 'ax-1', role: { value: 'button' }, name: { value: 'Follow' }, backendDOMNodeId: 101, ignored: false, properties: [] }] });
           }
@@ -1087,6 +1102,7 @@ describe('PuppeteerBackend', () => {
     function setupTypeMocks() {
       const session = {
         send: vi.fn().mockImplementation((method: string) => {
+          if (method === 'Page.getFrameTree') return Promise.resolve({ frameTree: { frame: { id: 'main', url: 'https://example.com', securityOrigin: 'https://example.com' } } });
           if (method === 'Accessibility.getFullAXTree') {
             return Promise.resolve({
               nodes: [
@@ -1142,6 +1158,7 @@ describe('PuppeteerBackend', () => {
     it('wraps DOM.focus failure as ElementNotFound', async () => {
       const session = {
         send: vi.fn().mockImplementation((method: string) => {
+          if (method === 'Page.getFrameTree') return Promise.resolve({ frameTree: { frame: { id: 'main', url: 'https://example.com', securityOrigin: 'https://example.com' } } });
           if (method === 'Accessibility.getFullAXTree') {
             return Promise.resolve({
               nodes: [{
@@ -1375,6 +1392,7 @@ describe('PuppeteerBackend', () => {
     function setupScrollIntoViewMocks() {
       const session = {
         send: vi.fn().mockImplementation((method: string) => {
+          if (method === 'Page.getFrameTree') return Promise.resolve({ frameTree: { frame: { id: 'main', url: 'https://example.com', securityOrigin: 'https://example.com' } } });
           if (method === 'Accessibility.getFullAXTree') {
             return Promise.resolve({
               nodes: [

--- a/tests/unit/snapshot-fetch.test.ts
+++ b/tests/unit/snapshot-fetch.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchAXData } from '../../packages/runtime/src/internal/primitives/snapshot/fetch.js';
+
+function mockClient(frameTree: any, axResults: Record<string, any[]>) {
+  return {
+    send: vi.fn().mockImplementation((method: string, params?: any) => {
+      if (method === 'Page.getFrameTree') {
+        return Promise.resolve({ frameTree });
+      }
+      if (method === 'Accessibility.getFullAXTree') {
+        const nodes = axResults[params?.frameId] ?? [];
+        return Promise.resolve({ nodes });
+      }
+      return Promise.resolve({});
+    }),
+  };
+}
+
+describe('fetchAXData', () => {
+  it('returns AX data for a single frame (no iframes)', async () => {
+    const client = mockClient(
+      { frame: { id: 'main', url: 'https://example.com', securityOrigin: 'https://example.com' } },
+      { main: [{ nodeId: '1', role: { value: 'button' }, name: { value: 'OK' } }] },
+    );
+
+    const result = await fetchAXData(client as any);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].frameId).toBe('main');
+    expect(result[0].frameUrl).toBe('https://example.com');
+    expect(result[0].isMainFrame).toBe(true);
+    expect(result[0].nodes).toHaveLength(1);
+  });
+
+  it('includes same-origin iframe frames', async () => {
+    const client = mockClient(
+      {
+        frame: { id: 'main', url: 'https://app.example.com', securityOrigin: 'https://app.example.com' },
+        childFrames: [{
+          frame: { id: 'iframe-1', url: 'https://app.example.com/form', securityOrigin: 'https://app.example.com' },
+        }],
+      },
+      {
+        main: [{ nodeId: '1', role: { value: 'RootWebArea' } }],
+        'iframe-1': [{ nodeId: '2', role: { value: 'button' }, name: { value: 'Submit' } }],
+      },
+    );
+
+    const result = await fetchAXData(client as any);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].frameId).toBe('main');
+    expect(result[0].isMainFrame).toBe(true);
+    expect(result[1].frameId).toBe('iframe-1');
+    expect(result[1].frameUrl).toBe('https://app.example.com/form');
+    expect(result[1].isMainFrame).toBe(false);
+  });
+
+  it('skips cross-origin iframes (OOPIF)', async () => {
+    const client = mockClient(
+      {
+        frame: { id: 'main', url: 'https://app.example.com', securityOrigin: 'https://app.example.com' },
+        childFrames: [{
+          frame: { id: 'oopif', url: 'https://ads.thirdparty.com', securityOrigin: 'https://ads.thirdparty.com' },
+        }],
+      },
+      { main: [{ nodeId: '1' }] },
+    );
+
+    const result = await fetchAXData(client as any);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].frameId).toBe('main');
+  });
+
+  it('respects MAX_IFRAME_DEPTH', async () => {
+    function buildDeepTree(depth: number, origin: string): any {
+      const frame = { id: `frame-${depth}`, url: `${origin}/d${depth}`, securityOrigin: origin };
+      if (depth >= 7) return { frame };
+      return { frame, childFrames: [buildDeepTree(depth + 1, origin)] };
+    }
+
+    const tree = buildDeepTree(0, 'https://example.com');
+    const axResults: Record<string, any[]> = {};
+    for (let i = 0; i <= 7; i++) axResults[`frame-${i}`] = [{ nodeId: `n${i}` }];
+
+    const client = mockClient(tree, axResults);
+    const result = await fetchAXData(client as any);
+
+    // MAX_IFRAME_DEPTH = 5, so frames at depth 0-5 included, 6-7 excluded
+    expect(result.length).toBeLessThanOrEqual(6);
+  });
+
+  it('respects MAX_IFRAMES count limit', async () => {
+    const origin = 'https://example.com';
+    const childFrames = Array.from({ length: 120 }, (_, i) => ({
+      frame: { id: `iframe-${i}`, url: `${origin}/f${i}`, securityOrigin: origin },
+    }));
+    const tree = {
+      frame: { id: 'main', url: origin, securityOrigin: origin },
+      childFrames,
+    };
+    const axResults: Record<string, any[]> = { main: [{ nodeId: 'n0' }] };
+    for (let i = 0; i < 120; i++) axResults[`iframe-${i}`] = [{ nodeId: `n${i + 1}` }];
+
+    const client = mockClient(tree, axResults);
+    const result = await fetchAXData(client as any);
+
+    expect(result.length).toBeLessThanOrEqual(100);
+  });
+
+  it('handles getFullAXTree failure for a frame gracefully', async () => {
+    const client = {
+      send: vi.fn().mockImplementation((method: string, params?: any) => {
+        if (method === 'Page.getFrameTree') {
+          return Promise.resolve({
+            frameTree: {
+              frame: { id: 'main', url: 'https://example.com', securityOrigin: 'https://example.com' },
+              childFrames: [{
+                frame: { id: 'broken', url: 'https://example.com/broken', securityOrigin: 'https://example.com' },
+              }],
+            },
+          });
+        }
+        if (method === 'Accessibility.getFullAXTree') {
+          if (params?.frameId === 'broken') return Promise.reject(new Error('Frame not found'));
+          return Promise.resolve({ nodes: [{ nodeId: '1' }] });
+        }
+        return Promise.resolve({});
+      }),
+    };
+
+    const result = await fetchAXData(client as any);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].frameId).toBe('main');
+  });
+
+  it('falls back to single-frame when Page.getFrameTree fails (Chrome <120)', async () => {
+    const client = {
+      send: vi.fn().mockImplementation((method: string) => {
+        if (method === 'Page.getFrameTree') return Promise.reject(new Error('not supported'));
+        if (method === 'Accessibility.getFullAXTree') {
+          return Promise.resolve({ nodes: [{ nodeId: '1', role: { value: 'button' } }] });
+        }
+        return Promise.resolve({});
+      }),
+    };
+
+    const result = await fetchAXData(client as any);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].isMainFrame).toBe(true);
+    expect(result[0].nodes).toHaveLength(1);
+  });
+});

--- a/tests/unit/snapshot-integration.test.ts
+++ b/tests/unit/snapshot-integration.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../src/config.js', () => ({
+  getClickEnhancementConfig: vi.fn(() => ({ trajectory: false, jitter: false, occlusionCheck: false })),
+}));
+vi.mock('../../packages/runtime/src/internal/primitives/scroll-enhanced.js', () => ({
+  humanScroll: vi.fn(), scrollElementIntoView: vi.fn(),
+}));
+vi.mock('../../packages/runtime/src/internal/primitives/click-enhanced.js', () => ({
+  applyJitter: vi.fn((x: number, y: number) => ({ x, y })),
+  checkOcclusion: vi.fn().mockResolvedValue({ occluded: false }),
+  waitForElementStable: vi.fn().mockResolvedValue({ center: { x: 0, y: 0 }, box: { x: 0, y: 0, width: 10, height: 10 } }),
+  clickWithTrajectory: vi.fn(), injectCoordFix: vi.fn(),
+}));
+
+import { PuppeteerBackend } from '../../packages/runtime/src/internal/primitives/puppeteer-backend.js';
+
+function createMockPageWithFrames(frameTree: any, axResults: Record<string, any[]>) {
+  const session = {
+    send: vi.fn().mockImplementation((method: string, params?: any) => {
+      if (method === 'Page.getFrameTree') return Promise.resolve({ frameTree });
+      if (method === 'Accessibility.getFullAXTree') {
+        return Promise.resolve({ nodes: axResults[params?.frameId] ?? [] });
+      }
+      return Promise.resolve({});
+    }),
+    detach: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const page = {
+    url: vi.fn().mockReturnValue('https://example.com'),
+    createCDPSession: vi.fn().mockResolvedValue(session),
+    bringToFront: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue(undefined),
+    on: vi.fn(), off: vi.fn(),
+    mouse: { click: vi.fn(), wheel: vi.fn(), move: vi.fn() },
+    keyboard: { type: vi.fn(), press: vi.fn(), sendCharacter: vi.fn() },
+  };
+
+  return { page, session };
+}
+
+describe('takeSnapshot pipeline integration', () => {
+  it('single frame — behaves identically to original', async () => {
+    const { page } = createMockPageWithFrames(
+      { frame: { id: 'main', url: 'https://example.com', securityOrigin: 'https://example.com' } },
+      {
+        main: [
+          { nodeId: 'a1', role: { value: 'button' }, name: { value: 'Follow' }, backendDOMNodeId: 101, ignored: false, properties: [] },
+          { nodeId: 'a2', role: { value: 'link' }, name: { value: 'Home' }, backendDOMNodeId: 102, ignored: false, properties: [] },
+        ],
+      },
+    );
+
+    const backend = new PuppeteerBackend({ page: page as any, siteDomains: { test: ['example.com'] } });
+    const snapshot = await backend.takeSnapshot();
+
+    expect(snapshot.idToNode.size).toBe(2);
+    expect(snapshot.idToNode.get('1')!.role).toBe('button');
+    expect(snapshot.idToNode.get('1')!.name).toBe('Follow');
+    expect(snapshot.idToNode.get('1')!.frameUrl).toBeUndefined();
+    expect(snapshot.idToNode.get('2')!.role).toBe('link');
+  });
+
+  it('multi-frame — includes iframe nodes with frameUrl', async () => {
+    const { page } = createMockPageWithFrames(
+      {
+        frame: { id: 'main', url: 'https://app.example.com', securityOrigin: 'https://app.example.com' },
+        childFrames: [{
+          frame: { id: 'iframe-1', url: 'https://app.example.com/form', securityOrigin: 'https://app.example.com' },
+        }],
+      },
+      {
+        main: [
+          { nodeId: 'a1', role: { value: 'button' }, name: { value: 'Send' }, backendDOMNodeId: 100, ignored: false, properties: [] },
+        ],
+        'iframe-1': [
+          { nodeId: 'b1', role: { value: 'textbox' }, name: { value: 'Email' }, backendDOMNodeId: 200, ignored: false, properties: [] },
+          { nodeId: 'b2', role: { value: 'button' }, name: { value: 'Submit' }, backendDOMNodeId: 201, ignored: false, properties: [] },
+        ],
+      },
+    );
+
+    const backend = new PuppeteerBackend({ page: page as any, siteDomains: { test: ['example.com'] } });
+    const snapshot = await backend.takeSnapshot();
+
+    expect(snapshot.idToNode.size).toBe(3);
+
+    // Main frame node — no frameUrl
+    expect(snapshot.idToNode.get('1')!.name).toBe('Send');
+    expect(snapshot.idToNode.get('1')!.frameUrl).toBeUndefined();
+
+    // iframe nodes — have frameUrl
+    expect(snapshot.idToNode.get('2')!.name).toBe('Email');
+    expect(snapshot.idToNode.get('2')!.frameUrl).toBe('https://app.example.com/form');
+    expect(snapshot.idToNode.get('3')!.name).toBe('Submit');
+    expect(snapshot.idToNode.get('3')!.frameUrl).toBe('https://app.example.com/form');
+  });
+
+  it('cross-origin iframe is excluded', async () => {
+    const { page } = createMockPageWithFrames(
+      {
+        frame: { id: 'main', url: 'https://app.example.com', securityOrigin: 'https://app.example.com' },
+        childFrames: [{
+          frame: { id: 'oopif', url: 'https://ads.other.com', securityOrigin: 'https://ads.other.com' },
+        }],
+      },
+      {
+        main: [
+          { nodeId: 'a1', role: { value: 'button' }, name: { value: 'OK' }, backendDOMNodeId: 100, ignored: false, properties: [] },
+        ],
+        oopif: [
+          { nodeId: 'c1', role: { value: 'link' }, name: { value: 'Ad' }, backendDOMNodeId: 300, ignored: false, properties: [] },
+        ],
+      },
+    );
+
+    const backend = new PuppeteerBackend({ page: page as any, siteDomains: { test: ['example.com'] } });
+    const snapshot = await backend.takeSnapshot();
+
+    expect(snapshot.idToNode.size).toBe(1);
+    expect(snapshot.idToNode.get('1')!.name).toBe('OK');
+  });
+});

--- a/tests/unit/snapshot-merge.test.ts
+++ b/tests/unit/snapshot-merge.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { mergeAXData } from '../../packages/runtime/src/internal/primitives/snapshot/merge.js';
+import type { RawFrameAX } from '../../packages/runtime/src/internal/primitives/snapshot/types.js';
+
+function axNode(nodeId: string, role: string, name: string, backendDOMNodeId?: number, extra?: any) {
+  return {
+    nodeId,
+    role: { value: role },
+    name: { value: name },
+    backendDOMNodeId: backendDOMNodeId ?? null,
+    ignored: false,
+    properties: [],
+    ...extra,
+  };
+}
+
+describe('mergeAXData', () => {
+  it('assigns sequential uids across frames', () => {
+    const data: RawFrameAX[] = [
+      { frameId: 'main', frameUrl: 'https://example.com', isMainFrame: true, nodes: [axNode('a1', 'button', 'OK', 100)] },
+      { frameId: 'iframe', frameUrl: 'https://example.com/form', isMainFrame: false, nodes: [axNode('b1', 'textbox', 'Name', 200)] },
+    ];
+
+    const result = mergeAXData(data);
+
+    expect(result.nodes).toHaveLength(2);
+    expect(result.nodes[0].uid).toBe('1');
+    expect(result.nodes[1].uid).toBe('2');
+  });
+
+  it('sets frameUrl only for iframe nodes, undefined for main frame', () => {
+    const data: RawFrameAX[] = [
+      { frameId: 'main', frameUrl: 'https://example.com', isMainFrame: true, nodes: [axNode('a1', 'button', 'OK', 100)] },
+      { frameId: 'iframe', frameUrl: 'https://example.com/form', isMainFrame: false, nodes: [axNode('b1', 'textbox', 'Name', 200)] },
+    ];
+
+    const result = mergeAXData(data);
+
+    expect(result.nodes[0].frameUrl).toBeUndefined();
+    expect(result.nodes[1].frameUrl).toBe('https://example.com/form');
+  });
+
+  it('populates uidToBackendNodeId map', () => {
+    const data: RawFrameAX[] = [
+      { frameId: 'main', frameUrl: 'https://example.com', isMainFrame: true, nodes: [
+        axNode('a1', 'button', 'OK', 101),
+        axNode('a2', 'link', 'Home', 102),
+      ]},
+    ];
+
+    const result = mergeAXData(data);
+
+    expect(result.uidToBackendNodeId.get('1')).toBe(101);
+    expect(result.uidToBackendNodeId.get('2')).toBe(102);
+  });
+
+  it('skips ignored nodes', () => {
+    const data: RawFrameAX[] = [
+      { frameId: 'main', frameUrl: 'https://example.com', isMainFrame: true, nodes: [
+        { nodeId: 'x', role: { value: 'none' }, name: { value: '' }, ignored: true, properties: [] },
+        axNode('a1', 'button', 'OK', 101),
+      ]},
+    ];
+
+    const result = mergeAXData(data);
+
+    expect(result.nodes).toHaveLength(1);
+    expect(result.nodes[0].uid).toBe('1');
+  });
+
+  it('skips nodes with role=none or role=Ignored', () => {
+    const data: RawFrameAX[] = [
+      { frameId: 'main', frameUrl: 'https://example.com', isMainFrame: true, nodes: [
+        axNode('x1', 'none', '', 100),
+        axNode('x2', 'Ignored', '', 101),
+        axNode('a1', 'button', 'OK', 102),
+      ]},
+    ];
+
+    const result = mergeAXData(data);
+
+    expect(result.nodes).toHaveLength(1);
+  });
+
+  it('handles nodes without backendDOMNodeId', () => {
+    const data: RawFrameAX[] = [
+      { frameId: 'main', frameUrl: 'https://example.com', isMainFrame: true, nodes: [
+        axNode('a1', 'button', 'OK'),
+      ]},
+    ];
+
+    const result = mergeAXData(data);
+
+    expect(result.nodes).toHaveLength(1);
+    expect(result.uidToBackendNodeId.has('1')).toBe(false);
+  });
+
+  it('scopes axIdToUid by frameId to prevent cross-frame collisions', () => {
+    const data: RawFrameAX[] = [
+      { frameId: 'main', frameUrl: 'https://example.com', isMainFrame: true, nodes: [axNode('a1', 'button', 'OK', 100)] },
+      { frameId: 'iframe', frameUrl: 'https://example.com/form', isMainFrame: false, nodes: [axNode('a1', 'textbox', 'Name', 200)] },
+    ];
+
+    const result = mergeAXData(data);
+
+    // Same nodeId 'a1' in different frames should map to different uids
+    expect(result.axIdToUid.get('main:a1')).toBe('1');
+    expect(result.axIdToUid.get('iframe:a1')).toBe('2');
+  });
+
+  it('handles empty frame (no nodes)', () => {
+    const data: RawFrameAX[] = [
+      { frameId: 'main', frameUrl: 'https://example.com', isMainFrame: true, nodes: [axNode('a1', 'button', 'OK', 100)] },
+      { frameId: 'empty', frameUrl: 'https://example.com/empty', isMainFrame: false, nodes: [] },
+    ];
+
+    const result = mergeAXData(data);
+
+    expect(result.nodes).toHaveLength(1);
+  });
+});

--- a/tests/unit/snapshot-output.test.ts
+++ b/tests/unit/snapshot-output.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { buildSnapshotOutput } from '../../packages/runtime/src/internal/primitives/snapshot/output.js';
+import type { MergedNode } from '../../packages/runtime/src/internal/primitives/snapshot/types.js';
+
+const DEFAULT_FRAME = 'main';
+
+function mergedNode(uid: string, role: string, name: string, opts?: {
+  frameId?: string;
+  frameUrl?: string;
+  value?: any;
+  properties?: any[];
+  childIds?: string[];
+}): MergedNode {
+  return {
+    uid,
+    axNode: {
+      nodeId: `ax-${uid}`,
+      role: { value: role },
+      name: { value: name },
+      value: opts?.value != null ? { value: opts.value } : undefined,
+      properties: opts?.properties ?? [],
+      childIds: opts?.childIds,
+    },
+    backendNodeId: null,
+    frameId: opts?.frameId ?? DEFAULT_FRAME,
+    frameUrl: opts?.frameUrl,
+  };
+}
+
+describe('buildSnapshotOutput', () => {
+  it('builds SnapshotNode with role, name, uid', () => {
+    const axIdToUid = new Map([['main:ax-1', '1']]);
+    const snapshot = buildSnapshotOutput([mergedNode('1', 'button', 'OK')], axIdToUid);
+
+    const node = snapshot.idToNode.get('1');
+    expect(node).toBeDefined();
+    expect(node!.role).toBe('button');
+    expect(node!.name).toBe('OK');
+    expect(node!.uid).toBe('1');
+  });
+
+  it('sets frameUrl for iframe nodes, omits for main frame', () => {
+    const nodes = [
+      mergedNode('1', 'button', 'Main'),
+      mergedNode('2', 'button', 'InFrame', { frameId: 'iframe-1', frameUrl: 'https://example.com/form' }),
+    ];
+    const axIdToUid = new Map([['main:ax-1', '1'], ['iframe-1:ax-2', '2']]);
+    const snapshot = buildSnapshotOutput(nodes, axIdToUid);
+
+    expect(snapshot.idToNode.get('1')!.frameUrl).toBeUndefined();
+    expect(snapshot.idToNode.get('2')!.frameUrl).toBe('https://example.com/form');
+  });
+
+  it('extracts optional properties (disabled, focused, expanded, selected, level)', () => {
+    const nodes = [mergedNode('1', 'button', 'Save', {
+      properties: [
+        { name: 'disabled', value: { value: true } },
+        { name: 'focused', value: { value: true } },
+        { name: 'expanded', value: { value: false } },
+        { name: 'selected', value: { value: true } },
+        { name: 'level', value: { value: 3 } },
+      ],
+    })];
+    const snapshot = buildSnapshotOutput(nodes, new Map([['main:ax-1', '1']]));
+
+    const node = snapshot.idToNode.get('1')!;
+    expect(node.disabled).toBe(true);
+    expect(node.focused).toBe(true);
+    expect(node.expanded).toBe(false);
+    expect(node.selected).toBe(true);
+    expect(node.level).toBe(3);
+  });
+
+  it('extracts value for form elements', () => {
+    const nodes = [mergedNode('1', 'textbox', 'Email', { value: 'a@b.com' })];
+    const snapshot = buildSnapshotOutput(nodes, new Map([['main:ax-1', '1']]));
+
+    expect(snapshot.idToNode.get('1')!.value).toBe('a@b.com');
+  });
+
+  it('resolves children within the same frame', () => {
+    const nodes = [
+      mergedNode('1', 'navigation', 'Nav', { childIds: ['ax-2', 'ax-3'] }),
+      mergedNode('2', 'link', 'Home'),
+      mergedNode('3', 'link', 'Profile'),
+    ];
+    const axIdToUid = new Map([['main:ax-1', '1'], ['main:ax-2', '2'], ['main:ax-3', '3']]);
+    const snapshot = buildSnapshotOutput(nodes, axIdToUid);
+
+    expect(snapshot.idToNode.get('1')!.children).toEqual(['2', '3']);
+  });
+
+  it('omits children array when no valid children exist', () => {
+    const nodes = [mergedNode('1', 'button', 'OK', { childIds: ['ax-gone'] })];
+    const axIdToUid = new Map([['main:ax-1', '1']]);
+    const snapshot = buildSnapshotOutput(nodes, axIdToUid);
+
+    expect(snapshot.idToNode.get('1')!.children).toBeUndefined();
+  });
+
+  it('does not cross frame boundaries for children', () => {
+    const nodes = [
+      mergedNode('1', 'navigation', 'Nav', { childIds: ['ax-2'] }),
+      mergedNode('2', 'button', 'Submit', { frameId: 'iframe-1', frameUrl: 'https://example.com/form' }),
+    ];
+    // main:ax-2 doesn't exist, iframe-1:ax-2 is a different key
+    const axIdToUid = new Map([['main:ax-1', '1'], ['iframe-1:ax-2', '2']]);
+    const snapshot = buildSnapshotOutput(nodes, axIdToUid);
+
+    // main frame's childId 'ax-2' resolves to 'main:ax-2' which is not in the map
+    expect(snapshot.idToNode.get('1')!.children).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Refactors `takeSnapshot()` from monolith into **fetch → hydrate → merge → filter → output** pipeline
- Adds same-origin iframe visibility via `Page.getFrameTree` + per-frame `getFullAXTree({frameId})`
- Adds `frameUrl?: string` field to `SnapshotNode` for iframe disambiguation
- Adds ops-level `hover()` utility for hover-to-reveal workflows
- Pipeline stages are independently testable pure functions; hydrate/filter are passthrough in M1, reserved for M2-M4

## Key design decisions

- `axIdToUid` scoped by `${frameId}:${nodeId}` to prevent cross-frame AX nodeId collisions
- `Promise.allSettled` for per-frame AX retrieval — one broken frame doesn't crash the snapshot
- Graceful fallback to single-frame mode when `Page.getFrameTree` unavailable (Chrome <120)
- `Primitives` interface unchanged, click/type/scroll paths zero modification

## Test plan

- [x] 30 new unit tests (fetch/merge/output/integration/hover) — all pass
- [x] 64 existing puppeteer-backend tests — all pass (mocks updated for `Page.getFrameTree`)
- [x] E2E verified against live impact.com: hover → click → iframe dialog → pipeline captures 139 AX nodes with 18 interactive elements, all with valid `backendNodeId`
- [x] Type-check clean (runtime package + main project)

## References

- Spec: `.dev/docs/superpowers/specs/2026-04-09-iframe-support-pipeline-design.md`
- Roadmap: `.dev/docs/dom-dehydration-implementation-roadmap.md`
- Issue: WilliamPenrose/site-use-dev#8