### PR TITLE
feat(snapshot): M2 — DOMSnapshot integration + ClickableElementDetector

### DIFF
--- a/packages/runtime/src/internal/primitives/puppeteer-backend.ts
+++ b/packages/runtime/src/internal/primitives/puppeteer-backend.ts
@@ -26,7 +26,7 @@ import type {
 } from './types.js';
 import { fetchAXData } from './snapshot/fetch.js';
 import { hydrateAXData } from './snapshot/hydrate.js';
-import { mergeAXData } from './snapshot/merge.js';
+import { mergeAxData } from './snapshot/merge.js';
 import { filterNodes } from './snapshot/filter.js';
 import { buildSnapshotOutput } from './snapshot/output.js';
 import { RateLimitDetector } from './rate-limit-detect.js';
@@ -416,7 +416,7 @@ export class PuppeteerBackend implements Primitives {
       // 5-stage pipeline: fetch → hydrate → merge → filter → output
       const rawData = await fetchAXData(client);
       const hydrated = hydrateAXData(rawData);
-      const { nodes, uidToBackendNodeId, axIdToUid } = mergeAXData(hydrated);
+      const { nodes, uidToBackendNodeId, axIdToUid } = mergeAxData(hydrated);
       const filtered = filterNodes(nodes);
       // TODO(M2): When filter becomes non-trivial, recompute uidToBackendNodeId and
       // axIdToUid from `filtered` to avoid dangling children refs and stale click targets.

--- a/packages/runtime/src/internal/primitives/puppeteer-backend.ts
+++ b/packages/runtime/src/internal/primitives/puppeteer-backend.ts
@@ -24,9 +24,9 @@ import type {
   InterceptHandler,
   InterceptControl,
 } from './types.js';
-import { fetchAXData } from './snapshot/fetch.js';
-import { hydrateAXData } from './snapshot/hydrate.js';
-import { mergeAxData } from './snapshot/merge.js';
+import { fetchSnapshotData } from './snapshot/fetch.js';
+import { hydrateAXData, hydrateDomSnapshot } from './snapshot/hydrate.js';
+import { mergeAxData, mergeDomSnapshot } from './snapshot/merge.js';
 import { filterNodes } from './snapshot/filter.js';
 import { buildSnapshotOutput } from './snapshot/output.js';
 import { RateLimitDetector } from './rate-limit-detect.js';
@@ -413,16 +413,27 @@ export class PuppeteerBackend implements Primitives {
     const client = await page.createCDPSession();
 
     try {
-      // 5-stage pipeline: fetch → hydrate → merge → filter → output
-      const rawData = await fetchAXData(client);
-      const hydrated = hydrateAXData(rawData);
-      const { nodes, uidToBackendNodeId, axIdToUid } = mergeAxData(hydrated);
-      const filtered = filterNodes(nodes);
-      // TODO(M2): When filter becomes non-trivial, recompute uidToBackendNodeId and
-      // axIdToUid from `filtered` to avoid dangling children refs and stale click targets.
-      const snapshot = buildSnapshotOutput(filtered, axIdToUid);
+      const { frames, domSnapshot } = await fetchSnapshotData(client);
+      const hydratedAx = hydrateAXData(frames);
 
-      this.uidToBackendNodeId = uidToBackendNodeId;
+      const dpr = await page.evaluate('window.devicePixelRatio').catch(() => 1) as number;
+      const domLookup = hydrateDomSnapshot(domSnapshot, dpr || 1);
+
+      const baseMerge = mergeAxData(hydratedAx);
+
+      // Build frameUrl map + identify main frameId for M2 inject
+      const frameUrlByFrameId = new Map<string, string>();
+      let mainFrameId = '';
+      for (const f of frames) {
+        frameUrlByFrameId.set(f.frameId, f.frameUrl);
+        if (f.isMainFrame) mainFrameId = f.frameId;
+      }
+
+      const merged = mergeDomSnapshot(baseMerge, domLookup, frameUrlByFrameId, mainFrameId);
+      const filtered = filterNodes(merged.nodes);
+      const snapshot = buildSnapshotOutput(filtered, merged.axIdToUid);
+
+      this.uidToBackendNodeId = merged.uidToBackendNodeId;
       return snapshot;
     } finally {
       await client.detach();

--- a/packages/runtime/src/internal/primitives/snapshot/clickable-detector.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/clickable-detector.ts
@@ -14,8 +14,36 @@ const INTERACTIVE_ROLES = new Set([
 
 const SEARCH_INDICATORS = ['search', 'magnify', 'glass', 'lookup', 'find', 'query', 'searchbox'];
 const ICON_ATTRS = new Set(['class', 'role', 'onclick', 'data-action', 'aria-label']);
+const FORM_CONTROL_TAGS = new Set(['input', 'select', 'textarea']);
 
 export class ClickableElementDetector {
+  private static childrenIndex: WeakMap<DomLookup, Map<number, number[]>> = new WeakMap();
+
+  private static getChildren(lookup: DomLookup, backendId: number): number[] {
+    let idx = this.childrenIndex.get(lookup);
+    if (!idx) {
+      idx = new Map();
+      for (const [bid, e] of lookup) {
+        if (e.parentBackendNodeId == null) continue;
+        if (!idx.has(e.parentBackendNodeId)) idx.set(e.parentBackendNodeId, []);
+        idx.get(e.parentBackendNodeId)!.push(bid);
+      }
+      this.childrenIndex.set(lookup, idx);
+    }
+    return idx.get(backendId) ?? [];
+  }
+
+  private static hasFormControlDescendant(entry: DomEntry, lookup: DomLookup, depth: number): boolean {
+    if (depth <= 0) return false;
+    for (const childId of this.getChildren(lookup, entry.backendNodeId)) {
+      const child = lookup.get(childId);
+      if (!child || child.nodeType !== 1) continue;
+      if (FORM_CONTROL_TAGS.has(child.tag)) return true;
+      if (this.hasFormControlDescendant(child, lookup, depth - 1)) return true;
+    }
+    return false;
+  }
+
   /**
    * Decide if a DOM node should be treated as interactive.
    * Port of browser-use's clickable_elements.py (Python). 9 heuristic branches.
@@ -50,6 +78,15 @@ export class ClickableElementDetector {
         if ((name === 'required' || name === 'autocomplete') && value) return true;
         if (name === 'keyshortcuts' && value) return true;
       }
+    }
+
+    // label proxying via "for" attribute → skip (would double-activate external input)
+    if (entry.tag === 'label' && entry.attributes['for']) return false;
+
+    // label/span wrapping form control (e.g. Ant Design's <label><span><input/></span></label>)
+    if ((entry.tag === 'label' || entry.tag === 'span') &&
+        ClickableElementDetector.hasFormControlDescendant(entry, domLookup, 2)) {
+      return true;
     }
 
     // Search indicators in class / id / data-*

--- a/packages/runtime/src/internal/primitives/snapshot/clickable-detector.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/clickable-detector.ts
@@ -1,0 +1,31 @@
+import type { DomEntry, DomLookup } from './types.js';
+
+const INTERACTIVE_TAGS = new Set([
+  'button', 'input', 'select', 'textarea', 'a', 'details', 'summary', 'option', 'optgroup',
+]);
+
+export class ClickableElementDetector {
+  /**
+   * Decide if a DOM node should be treated as interactive.
+   * Port of browser-use's clickable_elements.py (Python). 9 heuristic branches.
+   *
+   * @param entry  The DOM node from hydrated DomLookup.
+   * @param axNode The AX node sharing the same backendNodeId, or null if AX dropped it.
+   * @param domLookup Used by descendant traversal heuristics (label/span with form control).
+   */
+  static isInteractive(entry: DomEntry, axNode: any | null, domLookup: DomLookup): boolean {
+    if (entry.nodeType !== 1) return false;
+    if (entry.tag === 'html' || entry.tag === 'body') return false;
+
+    // iframe ≥100×100 is interactive (might be scrollable)
+    if (entry.tag === 'iframe' || entry.tag === 'frame') {
+      if (entry.bounds && entry.bounds.width > 100 && entry.bounds.height > 100) return true;
+      return false;
+    }
+
+    // Native interactive tags
+    if (INTERACTIVE_TAGS.has(entry.tag)) return true;
+
+    return false;
+  }
+}

--- a/packages/runtime/src/internal/primitives/snapshot/clickable-detector.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/clickable-detector.ts
@@ -26,6 +26,13 @@ export class ClickableElementDetector {
     // Native interactive tags
     if (INTERACTIVE_TAGS.has(entry.tag)) return true;
 
+    // DOMSnapshot.isClickable — Chrome's native "this node has click listener" signal
+    // (replaces browser-use's has_js_click_listener via Runtime.evaluate getEventListeners)
+    if (entry.isClickable) return true;
+
+    // Cursor pointer — final fallback for Vue/React style-driven interactives
+    if (entry.cursorStyle === 'pointer') return true;
+
     return false;
   }
 }

--- a/packages/runtime/src/internal/primitives/snapshot/clickable-detector.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/clickable-detector.ts
@@ -23,6 +23,24 @@ export class ClickableElementDetector {
       return false;
     }
 
+    // AX property checks — must come before positive-signal short-circuits
+    // because disabled/hidden override everything else
+    if (axNode?.properties) {
+      for (const prop of axNode.properties) {
+        const name = prop.name;
+        const value = prop.value?.value;
+        if ((name === 'disabled' || name === 'hidden') && value) return false;
+      }
+      for (const prop of axNode.properties) {
+        const name = prop.name;
+        const value = prop.value?.value;
+        if ((name === 'focusable' || name === 'editable' || name === 'settable') && value) return true;
+        if (name === 'checked' || name === 'expanded' || name === 'pressed' || name === 'selected') return true;
+        if ((name === 'required' || name === 'autocomplete') && value) return true;
+        if (name === 'keyshortcuts' && value) return true;
+      }
+    }
+
     // Native interactive tags
     if (INTERACTIVE_TAGS.has(entry.tag)) return true;
 

--- a/packages/runtime/src/internal/primitives/snapshot/clickable-detector.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/clickable-detector.ts
@@ -4,6 +4,14 @@ const INTERACTIVE_TAGS = new Set([
   'button', 'input', 'select', 'textarea', 'a', 'details', 'summary', 'option', 'optgroup',
 ]);
 
+const INTERACTIVE_ATTRS = new Set(['onclick', 'onmousedown', 'onmouseup', 'onkeydown', 'onkeyup', 'tabindex']);
+
+const INTERACTIVE_ROLES = new Set([
+  'button', 'link', 'menuitem', 'option', 'radio', 'checkbox', 'tab',
+  'textbox', 'combobox', 'slider', 'spinbutton',
+  'search', 'searchbox', 'row', 'cell', 'gridcell',
+]);
+
 export class ClickableElementDetector {
   /**
    * Decide if a DOM node should be treated as interactive.
@@ -50,6 +58,19 @@ export class ClickableElementDetector {
 
     // Cursor pointer — final fallback for Vue/React style-driven interactives
     if (entry.cursorStyle === 'pointer') return true;
+
+    // Attribute-level interactive signals
+    for (const attr of Object.keys(entry.attributes)) {
+      if (INTERACTIVE_ATTRS.has(attr)) return true;
+    }
+
+    // role attribute -> interactive
+    const roleAttr = entry.attributes['role'];
+    if (roleAttr && INTERACTIVE_ROLES.has(roleAttr)) return true;
+
+    // AX role -> interactive
+    const axRole = axNode?.role?.value;
+    if (axRole && INTERACTIVE_ROLES.has(axRole)) return true;
 
     return false;
   }

--- a/packages/runtime/src/internal/primitives/snapshot/clickable-detector.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/clickable-detector.ts
@@ -12,6 +12,9 @@ const INTERACTIVE_ROLES = new Set([
   'search', 'searchbox', 'row', 'cell', 'gridcell',
 ]);
 
+const SEARCH_INDICATORS = ['search', 'magnify', 'glass', 'lookup', 'find', 'query', 'searchbox'];
+const ICON_ATTRS = new Set(['class', 'role', 'onclick', 'data-action', 'aria-label']);
+
 export class ClickableElementDetector {
   /**
    * Decide if a DOM node should be treated as interactive.
@@ -49,6 +52,18 @@ export class ClickableElementDetector {
       }
     }
 
+    // Search indicators in class / id / data-*
+    const cls = (entry.attributes['class'] ?? '').toLowerCase();
+    if (cls && SEARCH_INDICATORS.some(ind => cls.includes(ind))) return true;
+    const id = (entry.attributes['id'] ?? '').toLowerCase();
+    if (id && SEARCH_INDICATORS.some(ind => id.includes(ind))) return true;
+    for (const [name, value] of Object.entries(entry.attributes)) {
+      if (name.startsWith('data-')) {
+        const v = value.toLowerCase();
+        if (SEARCH_INDICATORS.some(ind => v.includes(ind))) return true;
+      }
+    }
+
     // Native interactive tags
     if (INTERACTIVE_TAGS.has(entry.tag)) return true;
 
@@ -71,6 +86,15 @@ export class ClickableElementDetector {
     // AX role -> interactive
     const axRole = axNode?.role?.value;
     if (axRole && INTERACTIVE_ROLES.has(axRole)) return true;
+
+    // Icon-sized elements with interactive-suggesting attrs
+    if (entry.bounds &&
+        entry.bounds.width >= 10 && entry.bounds.width <= 50 &&
+        entry.bounds.height >= 10 && entry.bounds.height <= 50) {
+      for (const attr of Object.keys(entry.attributes)) {
+        if (ICON_ATTRS.has(attr)) return true;
+      }
+    }
 
     return false;
   }

--- a/packages/runtime/src/internal/primitives/snapshot/clickable-detector.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/clickable-detector.ts
@@ -80,8 +80,16 @@ export class ClickableElementDetector {
       }
     }
 
-    // label proxying via "for" attribute → skip (would double-activate external input)
+    // label proxying via "for" attribute -> skip (would double-activate external input)
     if (entry.tag === 'label' && entry.attributes['for']) return false;
+
+    // DOM-level disabled gate — covers the AX-orphan path (axNode === null).
+    // M2's whole point is to surface elements AX dropped, so the AX disabled
+    // check above never fires for them; without this, a Vue/React div with
+    // aria-disabled="true" + cursor:pointer slips through.
+    const ariaDisabled = entry.attributes['aria-disabled'];
+    if (ariaDisabled === 'true' || ariaDisabled === '') return false;
+    if ('disabled' in entry.attributes) return false;
 
     // label/span wrapping form control (e.g. Ant Design's <label><span><input/></span></label>)
     if ((entry.tag === 'label' || entry.tag === 'span') &&

--- a/packages/runtime/src/internal/primitives/snapshot/derive-name.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/derive-name.ts
@@ -10,6 +10,42 @@ function truncate(s: string): string {
   return s.length > MAX_NAME_LEN ? s.slice(0, MAX_NAME_LEN) + '…' : s;
 }
 
+function buildChildrenIndex(lookup: DomLookup): Map<number, number[]> {
+  const idx = new Map<number, number[]>();
+  for (const [bid, e] of lookup) {
+    if (e.parentBackendNodeId == null) continue;
+    if (!idx.has(e.parentBackendNodeId)) idx.set(e.parentBackendNodeId, []);
+    idx.get(e.parentBackendNodeId)!.push(bid);
+  }
+  return idx;
+}
+
+const childrenIndexCache: WeakMap<DomLookup, Map<number, number[]>> = new WeakMap();
+
+function getChildren(lookup: DomLookup, backendId: number): number[] {
+  let idx = childrenIndexCache.get(lookup);
+  if (!idx) {
+    idx = buildChildrenIndex(lookup);
+    childrenIndexCache.set(lookup, idx);
+  }
+  return idx.get(backendId) ?? [];
+}
+
+function collectTextDescendants(entry: DomEntry, lookup: DomLookup): string {
+  const parts: string[] = [];
+  const stack: number[] = [...getChildren(lookup, entry.backendNodeId)];
+  for (let i = 0; i < stack.length; i++) {
+    const child = lookup.get(stack[i]);
+    if (!child) continue;
+    if (child.nodeType === 3 && child.nodeValue) {
+      parts.push(child.nodeValue);
+    } else if (child.nodeType === 1) {
+      stack.push(...getChildren(lookup, child.backendNodeId));
+    }
+  }
+  return parts.join('');
+}
+
 /**
  * Derive a human-readable name for an inferred or upgraded button-like node.
  * Priority: aria-label > title > descendant text content > placeholder > "".
@@ -27,7 +63,9 @@ export function deriveDomName(entry: DomEntry, domLookup: DomLookup): string {
     if (out) return truncate(out);
   }
 
-  // Descendant text aggregation (Task 12)
+  const text = collectTextDescendants(entry, domLookup);
+  const cleaned = clean(text);
+  if (cleaned) return truncate(cleaned);
 
   const placeholder = entry.attributes['placeholder'];
   if (placeholder) {

--- a/packages/runtime/src/internal/primitives/snapshot/derive-name.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/derive-name.ts
@@ -1,0 +1,39 @@
+import type { DomEntry, DomLookup } from './types.js';
+
+const MAX_NAME_LEN = 80;
+
+function clean(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+function truncate(s: string): string {
+  return s.length > MAX_NAME_LEN ? s.slice(0, MAX_NAME_LEN) + '…' : s;
+}
+
+/**
+ * Derive a human-readable name for an inferred or upgraded button-like node.
+ * Priority: aria-label > title > descendant text content > placeholder > "".
+ */
+export function deriveDomName(entry: DomEntry, domLookup: DomLookup): string {
+  const aria = entry.attributes['aria-label'];
+  if (aria) {
+    const out = clean(aria);
+    if (out) return truncate(out);
+  }
+
+  const title = entry.attributes['title'];
+  if (title) {
+    const out = clean(title);
+    if (out) return truncate(out);
+  }
+
+  // Descendant text aggregation (Task 12)
+
+  const placeholder = entry.attributes['placeholder'];
+  if (placeholder) {
+    const out = clean(placeholder);
+    if (out) return truncate(out);
+  }
+
+  return '';
+}

--- a/packages/runtime/src/internal/primitives/snapshot/fetch.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/fetch.ts
@@ -1,32 +1,47 @@
-import type { RawFrameAX } from './types.js';
+import type { RawFrameAX, RawSnapshotData, RawDomSnapshot } from './types.js';
 import { MAX_IFRAME_DEPTH, MAX_IFRAMES } from './types.js';
 
+const EMPTY_DOM: RawDomSnapshot = { documents: [], strings: [] };
+
 /**
- * Fetch AX tree data from all same-origin frames.
- * Traverses Page.getFrameTree, skips cross-origin iframes (OOPIF),
- * enforces depth and count limits.
+ * Fetch snapshot data from all same-origin frames.
+ * Combines per-frame AX (M1) and DOMSnapshot.captureSnapshot (M2) in parallel.
  */
-export async function fetchAXData(client: any): Promise<RawFrameAX[]> {
-  // Graceful degradation: if Page.getFrameTree is unavailable (Chrome <120),
-  // fall back to the original single-frame behavior.
-  let frameTree: any;
+export async function fetchSnapshotData(client: any): Promise<RawSnapshotData> {
+  let frames: RawFrameAX[];
   try {
-    ({ frameTree } = await client.send('Page.getFrameTree'));
+    frames = await fetchFrames(client);
   } catch {
     const { nodes } = await client.send('Accessibility.getFullAXTree');
-    return [{ frameId: '', frameUrl: '', isMainFrame: true, nodes }];
+    frames = [{ frameId: '', frameUrl: '', isMainFrame: true, nodes }];
   }
 
+  const domPromise = client.send('DOMSnapshot.captureSnapshot', {
+    computedStyles: ['cursor'],
+    includePaintOrder: false,
+    includeDOMRects: false,
+    includeBlendedBackgroundColors: false,
+    includeTextColorOpacities: false,
+  }).catch((err: any) => {
+    console.error(`[site-use] DOMSnapshot.captureSnapshot unavailable, M2 inference disabled this snapshot: ${err?.message ?? err}`);
+    return EMPTY_DOM;
+  });
+
+  const domSnapshot: RawDomSnapshot = await domPromise;
+  return { frames, domSnapshot };
+}
+
+async function fetchFrames(client: any): Promise<RawFrameAX[]> {
+  const { frameTree } = await client.send('Page.getFrameTree');
   const mainOrigin = frameTree.frame.securityOrigin;
   const mainFrameId = frameTree.frame.id;
 
-  const frames: Array<{ id: string; url: string; isMainFrame: boolean }> = [];
-
+  const collected: Array<{ id: string; url: string; isMainFrame: boolean }> = [];
   function walk(node: any, depth: number): void {
-    frames.push({ id: node.frame.id, url: node.frame.url, isMainFrame: node.frame.id === mainFrameId });
+    collected.push({ id: node.frame.id, url: node.frame.url, isMainFrame: node.frame.id === mainFrameId });
     if (depth >= MAX_IFRAME_DEPTH) return;
     for (const child of node.childFrames ?? []) {
-      if (frames.length >= MAX_IFRAMES) break;
+      if (collected.length >= MAX_IFRAMES) break;
       if (child.frame.securityOrigin !== mainOrigin) continue;
       walk(child, depth + 1);
     }
@@ -34,13 +49,18 @@ export async function fetchAXData(client: any): Promise<RawFrameAX[]> {
   walk(frameTree, 0);
 
   const results = await Promise.allSettled(
-    frames.map(async (f): Promise<RawFrameAX> => {
+    collected.map(async (f): Promise<RawFrameAX> => {
       const { nodes } = await client.send('Accessibility.getFullAXTree', { frameId: f.id });
       return { frameId: f.id, frameUrl: f.url, isMainFrame: f.isMainFrame, nodes };
     }),
   );
-
   return results
     .filter((r): r is PromiseFulfilledResult<RawFrameAX> => r.status === 'fulfilled')
     .map(r => r.value);
+}
+
+// Backward-compat alias used by existing tests/imports
+export async function fetchAXData(client: any): Promise<RawFrameAX[]> {
+  const { frames } = await fetchSnapshotData(client);
+  return frames;
 }

--- a/packages/runtime/src/internal/primitives/snapshot/fetch.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/fetch.ts
@@ -5,18 +5,11 @@ const EMPTY_DOM: RawDomSnapshot = { documents: [], strings: [] };
 
 /**
  * Fetch snapshot data from all same-origin frames.
- * Combines per-frame AX (M1) and DOMSnapshot.captureSnapshot (M2) in parallel.
+ * Fires per-frame AX (M1) and DOMSnapshot.captureSnapshot (M2) in parallel,
+ * then awaits both — saves one round-trip vs serializing them.
  */
 export async function fetchSnapshotData(client: any): Promise<RawSnapshotData> {
-  let frames: RawFrameAX[];
-  try {
-    frames = await fetchFrames(client);
-  } catch {
-    const { nodes } = await client.send('Accessibility.getFullAXTree');
-    frames = [{ frameId: '', frameUrl: '', isMainFrame: true, nodes }];
-  }
-
-  const domPromise = client.send('DOMSnapshot.captureSnapshot', {
+  const domPromise: Promise<RawDomSnapshot> = client.send('DOMSnapshot.captureSnapshot', {
     computedStyles: ['cursor'],
     includePaintOrder: false,
     includeDOMRects: false,
@@ -27,7 +20,15 @@ export async function fetchSnapshotData(client: any): Promise<RawSnapshotData> {
     return EMPTY_DOM;
   });
 
-  const domSnapshot: RawDomSnapshot = await domPromise;
+  let frames: RawFrameAX[];
+  try {
+    frames = await fetchFrames(client);
+  } catch {
+    const { nodes } = await client.send('Accessibility.getFullAXTree');
+    frames = [{ frameId: '', frameUrl: '', isMainFrame: true, nodes }];
+  }
+
+  const domSnapshot = await domPromise;
   return { frames, domSnapshot };
 }
 

--- a/packages/runtime/src/internal/primitives/snapshot/hydrate.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/hydrate.ts
@@ -24,6 +24,18 @@ export function hydrateDomSnapshot(
 
     const indexToBackendId: number[] = backendIds;
 
+    // Pre-build set for O(1) isClickable lookup (RareBooleanData stores indices)
+    const clickableSet = new Set<number>(nodes.isClickable?.index ?? []);
+
+    // Pre-build layout-index map (nodeIndex → layout entry index)
+    const layout = doc.layout ?? {};
+    const layoutNodeIndex: number[] = layout.nodeIndex ?? [];
+    const layoutIndexMap = new Map<number, number>();
+    for (let li = 0; li < layoutNodeIndex.length; li++) {
+      const nodeIdx = layoutNodeIndex[li];
+      if (!layoutIndexMap.has(nodeIdx)) layoutIndexMap.set(nodeIdx, li);
+    }
+
     for (let i = 0; i < backendIds.length; i++) {
       const backendNodeId = backendIds[i];
       const tagStrIdx = nodes.nodeName?.[i];
@@ -48,15 +60,40 @@ export function hydrateDomSnapshot(
       const nodeValue = (nodeValueIdx >= 0 && nodeValueIdx < strings.length)
         ? strings[nodeValueIdx] : null;
 
+      // Layout data (bounds + cursor) if this node has a layout entry
+      let bounds: DomEntry['bounds'] = null;
+      let cursorStyle: string | null = null;
+      const layoutIdx = layoutIndexMap.get(i);
+      if (layoutIdx != null) {
+        const rawBounds = layout.bounds?.[layoutIdx];
+        if (rawBounds && rawBounds.length >= 4) {
+          bounds = {
+            x: rawBounds[0] / devicePixelRatio,
+            y: rawBounds[1] / devicePixelRatio,
+            width: rawBounds[2] / devicePixelRatio,
+            height: rawBounds[3] / devicePixelRatio,
+          };
+        }
+        const styleIndices: number[] | undefined = layout.styles?.[layoutIdx];
+        if (styleIndices && styleIndices.length > 0) {
+          const cursorIdx = styleIndices[0];
+          if (cursorIdx >= 0 && cursorIdx < strings.length) {
+            cursorStyle = strings[cursorIdx];
+          }
+        }
+      }
+
+      const isClickable = clickableSet.has(i);
+
       const entry: DomEntry = {
         backendNodeId,
         frameId: doc.frame ?? '',
         parentBackendNodeId,
         tag,
         attributes: attrs,
-        bounds: null,
-        cursorStyle: null,
-        isClickable: false,
+        bounds,
+        cursorStyle,
+        isClickable,
         nodeType: nodes.nodeType?.[i] ?? 0,
         nodeValue,
       };

--- a/packages/runtime/src/internal/primitives/snapshot/hydrate.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/hydrate.ts
@@ -1,11 +1,68 @@
-import type { RawFrameAX } from './types.js';
+import type { RawFrameAX, RawDomSnapshot, DomLookup, DomEntry } from './types.js';
 
-/**
- * Hydrate raw CDP data into usable lookup structures.
- * M1: passthrough — AX data is already in usable format.
- * Future (M2): DOMSnapshot SoA → per-node lookup.
- * Future (M3): DOM tree → backendNodeId lookup.
- */
+/** AX hydrate (M1): passthrough. */
 export function hydrateAXData(rawData: RawFrameAX[]): RawFrameAX[] {
   return rawData;
+}
+
+/**
+ * Decode CDP DOMSnapshot SoA into a backendNodeId-indexed lookup.
+ * Each DocumentSnapshot represents one frame; documents are merged into one lookup
+ * because backendNodeId is globally unique across same-origin documents.
+ */
+export function hydrateDomSnapshot(
+  snapshot: RawDomSnapshot,
+  devicePixelRatio: number,
+): DomLookup {
+  const lookup: DomLookup = new Map();
+  const strings = snapshot.strings;
+
+  for (const doc of snapshot.documents) {
+    const nodes = doc.nodes;
+    const backendIds: number[] = nodes.backendNodeId ?? [];
+    if (backendIds.length === 0) continue;
+
+    const indexToBackendId: number[] = backendIds;
+
+    for (let i = 0; i < backendIds.length; i++) {
+      const backendNodeId = backendIds[i];
+      const tagStrIdx = nodes.nodeName?.[i];
+      const tag = (typeof tagStrIdx === 'number' && tagStrIdx >= 0 && tagStrIdx < strings.length)
+        ? strings[tagStrIdx].toLowerCase() : '';
+
+      const attrs: Record<string, string> = {};
+      const attrIndices = nodes.attributes?.[i] ?? [];
+      for (let a = 0; a + 1 < attrIndices.length; a += 2) {
+        const nameIdx = attrIndices[a];
+        const valueIdx = attrIndices[a + 1];
+        if (nameIdx < 0 || nameIdx >= strings.length) continue;
+        const value = (valueIdx >= 0 && valueIdx < strings.length) ? strings[valueIdx] : '';
+        attrs[strings[nameIdx]] = value;
+      }
+
+      const parentIdx = nodes.parentIndex?.[i] ?? -1;
+      const parentBackendNodeId = (parentIdx >= 0 && parentIdx < indexToBackendId.length)
+        ? indexToBackendId[parentIdx] : null;
+
+      const nodeValueIdx = nodes.nodeValue?.[i] ?? -1;
+      const nodeValue = (nodeValueIdx >= 0 && nodeValueIdx < strings.length)
+        ? strings[nodeValueIdx] : null;
+
+      const entry: DomEntry = {
+        backendNodeId,
+        frameId: doc.frame ?? '',
+        parentBackendNodeId,
+        tag,
+        attributes: attrs,
+        bounds: null,
+        cursorStyle: null,
+        isClickable: false,
+        nodeType: nodes.nodeType?.[i] ?? 0,
+        nodeValue,
+      };
+      lookup.set(backendNodeId, entry);
+    }
+  }
+
+  return lookup;
 }

--- a/packages/runtime/src/internal/primitives/snapshot/index.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/index.ts
@@ -1,7 +1,7 @@
 export { fetchAXData } from './fetch.js';
 export { hydrateAXData } from './hydrate.js';
-export { mergeAXData, type MergeResult } from './merge.js';
+export { mergeAxData } from './merge.js';
 export { filterNodes } from './filter.js';
 export { buildSnapshotOutput } from './output.js';
-export type { RawFrameAX, MergedNode } from './types.js';
+export type { RawFrameAX, MergedNode, MergeResult } from './types.js';
 export { MAX_IFRAME_DEPTH, MAX_IFRAMES } from './types.js';

--- a/packages/runtime/src/internal/primitives/snapshot/merge.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/merge.ts
@@ -1,4 +1,6 @@
-import type { RawFrameAX, MergedNode, MergeResult } from './types.js';
+import type { RawFrameAX, MergedNode, MergeResult, DomLookup } from './types.js';
+import { ClickableElementDetector } from './clickable-detector.js';
+import { deriveDomName } from './derive-name.js';
 
 function shouldSkipNode(node: any): boolean {
   if (node.ignored) return true;
@@ -44,4 +46,66 @@ export function mergeAxData(rawData: RawFrameAX[]): MergeResult {
   }
 
   return { nodes, uidToBackendNodeId, axIdToUid, axNodeByBackendId, backendIdToUid };
+}
+
+/**
+ * Cross-join AX-merged nodes with hydrated DOMSnapshot.
+ * For each DOM node the detector marks interactive:
+ *   - upgrade existing AX MergedNode (role generic/'' → button) — case ①
+ *   - inject new MergedNode for AX-orphan (cases ② AX never saw it; ③ AX shouldSkip dropped it)
+ *     [inject branch is filled in Task 15]
+ */
+export function mergeDomSnapshot(
+  base: MergeResult,
+  domLookup: DomLookup,
+  frameUrlByFrameId: Map<string, string>,
+  mainFrameId: string,
+): MergeResult {
+  const upgraded = new Map<string, { role: string; name: string }>();
+  const injected: MergedNode[] = [];
+
+  let maxUid = 0;
+  for (const n of base.nodes) {
+    const num = Number(n.uid);
+    if (Number.isFinite(num) && num > maxUid) maxUid = num;
+  }
+  let nextUid = maxUid + 1;
+  const finalUidToBackendNodeId = new Map(base.uidToBackendNodeId);
+
+  for (const [backendId, entry] of domLookup) {
+    if (entry.nodeType !== 1) continue;
+    const axNode = base.axNodeByBackendId.get(backendId) ?? null;
+    if (!ClickableElementDetector.isInteractive(entry, axNode, domLookup)) continue;
+
+    const inferredName = deriveDomName(entry, domLookup);
+    const existingUid = base.backendIdToUid.get(backendId);
+
+    if (existingUid != null) {
+      const existing = base.nodes.find(n => n.uid === existingUid);
+      const role = existing?.axNode?.role?.value ?? '';
+      if (role === 'generic' || role === '' || role === 'none') {
+        upgraded.set(existingUid, { role: 'button', name: inferredName });
+      }
+      // For other roles (button/link/textbox/...) keep AX as-is — already interactive.
+    } else {
+      // Inject branch — Task 15 will fill this in
+    }
+  }
+
+  const finalNodes = base.nodes.map(n => {
+    const u = upgraded.get(n.uid);
+    return u ? { ...n, upgrade: u } : n;
+  }).concat(injected);
+
+  // Suppress unused-variable warnings for variables reserved for Task 15.
+  void nextUid;
+  void finalUidToBackendNodeId;
+
+  return {
+    nodes: finalNodes,
+    uidToBackendNodeId: finalUidToBackendNodeId,
+    axIdToUid: base.axIdToUid,
+    axNodeByBackendId: base.axNodeByBackendId,
+    backendIdToUid: base.backendIdToUid,
+  };
 }

--- a/packages/runtime/src/internal/primitives/snapshot/merge.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/merge.ts
@@ -88,7 +88,16 @@ export function mergeDomSnapshot(
       }
       // For other roles (button/link/textbox/...) keep AX as-is — already interactive.
     } else {
-      // Inject branch — Task 15 will fill this in
+      const uid = String(nextUid++);
+      injected.push({
+        uid,
+        axNode: null,
+        backendNodeId: backendId,
+        frameId: entry.frameId,
+        frameUrl: entry.frameId === mainFrameId ? undefined : frameUrlByFrameId.get(entry.frameId),
+        inferred: { role: 'button', name: inferredName },
+      });
+      finalUidToBackendNodeId.set(uid, backendId);
     }
   }
 
@@ -96,10 +105,6 @@ export function mergeDomSnapshot(
     const u = upgraded.get(n.uid);
     return u ? { ...n, upgrade: u } : n;
   }).concat(injected);
-
-  // Suppress unused-variable warnings for variables reserved for Task 15.
-  void nextUid;
-  void finalUidToBackendNodeId;
 
   return {
     nodes: finalNodes,

--- a/packages/runtime/src/internal/primitives/snapshot/merge.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/merge.ts
@@ -1,10 +1,4 @@
-import type { RawFrameAX, MergedNode } from './types.js';
-
-export interface MergeResult {
-  nodes: MergedNode[];
-  uidToBackendNodeId: Map<string, number>;
-  axIdToUid: Map<string, string>;
-}
+import type { RawFrameAX, MergedNode, MergeResult } from './types.js';
 
 function shouldSkipNode(node: any): boolean {
   if (node.ignored) return true;
@@ -15,13 +9,15 @@ function shouldSkipNode(node: any): boolean {
 
 /**
  * Merge multi-frame AX data into a flat list of MergedNodes.
- * Assigns sequential uids, populates uidToBackendNodeId, filters ignored nodes.
- * First frame in the array is treated as the main frame (frameUrl = undefined).
+ * Now also returns reverse indexes (axNodeByBackendId, backendIdToUid)
+ * for M2 cross-join with DOMSnapshot.
  */
-export function mergeAXData(rawData: RawFrameAX[]): MergeResult {
+export function mergeAxData(rawData: RawFrameAX[]): MergeResult {
   const nodes: MergedNode[] = [];
   const uidToBackendNodeId = new Map<string, number>();
   const axIdToUid = new Map<string, string>();
+  const axNodeByBackendId = new Map<number, any>();
+  const backendIdToUid = new Map<number, string>();
   let nextUid = 1;
 
   for (const frame of rawData) {
@@ -29,12 +25,12 @@ export function mergeAXData(rawData: RawFrameAX[]): MergeResult {
       if (shouldSkipNode(axNode)) continue;
 
       const uid = String(nextUid++);
-      // Scope by frameId to prevent cross-frame nodeId collisions.
-      // CDP does not guarantee globally unique AX nodeIds across frames.
       axIdToUid.set(`${frame.frameId}:${axNode.nodeId}`, uid);
 
       if (axNode.backendDOMNodeId != null) {
         uidToBackendNodeId.set(uid, axNode.backendDOMNodeId);
+        axNodeByBackendId.set(axNode.backendDOMNodeId, axNode);
+        backendIdToUid.set(axNode.backendDOMNodeId, uid);
       }
 
       nodes.push({
@@ -47,5 +43,5 @@ export function mergeAXData(rawData: RawFrameAX[]): MergeResult {
     }
   }
 
-  return { nodes, uidToBackendNodeId, axIdToUid };
+  return { nodes, uidToBackendNodeId, axIdToUid, axNodeByBackendId, backendIdToUid };
 }

--- a/packages/runtime/src/internal/primitives/snapshot/output.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/output.ts
@@ -14,56 +14,46 @@ export function buildSnapshotOutput(
   for (const merged of nodes) {
     const { axNode } = merged;
 
+    // Priority chain: upgrade.* (M2) > inferred.* (M2) > axNode.* (M1)
+    const role = merged.upgrade?.role ?? merged.inferred?.role ?? axNode?.role?.value ?? '';
+    const name = merged.upgrade?.name ?? merged.inferred?.name ?? axNode?.name?.value ?? '';
+
     const snapshotNode: SnapshotNode = {
       uid: merged.uid,
-      role: axNode.role?.value ?? '',
-      name: axNode.name?.value ?? '',
+      role,
+      name,
     };
 
-    // frameUrl (only for iframe nodes)
     if (merged.frameUrl != null) {
       snapshotNode.frameUrl = merged.frameUrl;
     }
 
-    // Optional AX properties
-    if (axNode.properties) {
+    // AX-only properties (only present when axNode is set)
+    if (axNode?.properties) {
       for (const prop of axNode.properties) {
         const val = prop.value?.value;
         switch (prop.name) {
-          case 'focused':
-            if (val) snapshotNode.focused = true;
-            break;
-          case 'disabled':
-            if (val) snapshotNode.disabled = true;
-            break;
-          case 'expanded':
-            if (val != null) snapshotNode.expanded = val;
-            break;
-          case 'selected':
-            if (val) snapshotNode.selected = true;
-            break;
-          case 'level':
-            if (val != null) snapshotNode.level = val;
-            break;
+          case 'focused':  if (val) snapshotNode.focused = true; break;
+          case 'disabled': if (val) snapshotNode.disabled = true; break;
+          case 'expanded': if (val != null) snapshotNode.expanded = val; break;
+          case 'selected': if (val) snapshotNode.selected = true; break;
+          case 'level':    if (val != null) snapshotNode.level = val; break;
         }
       }
     }
 
-    // Value (form elements)
-    if (axNode.value?.value != null) {
+    if (axNode?.value?.value != null) {
       snapshotNode.value = String(axNode.value.value);
     }
 
-    // Children (resolve AX childIds to assigned uids, scoped by frameId)
-    if (axNode.childIds?.length) {
+    // Children resolution — skip for inferred nodes (no AX childIds)
+    if (axNode?.childIds?.length) {
       const childUids: string[] = [];
       for (const childId of axNode.childIds) {
         const childUid = axIdToUid.get(`${merged.frameId}:${childId}`);
         if (childUid) childUids.push(childUid);
       }
-      if (childUids.length > 0) {
-        snapshotNode.children = childUids;
-      }
+      if (childUids.length > 0) snapshotNode.children = childUids;
     }
 
     idToNode.set(merged.uid, snapshotNode);

--- a/packages/runtime/src/internal/primitives/snapshot/types.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/types.ts
@@ -6,13 +6,55 @@ export interface RawFrameAX {
   nodes: any[]; // CDP Protocol.Accessibility.AXNode[]
 }
 
+/** Raw DOMSnapshot data, returned by fetch stage. */
+export interface RawDomSnapshot {
+  documents: any[]; // CDP DocumentSnapshot[]
+  strings: string[];
+}
+
+/** Combined raw fetch output. */
+export interface RawSnapshotData {
+  frames: RawFrameAX[];
+  domSnapshot: RawDomSnapshot;
+}
+
+/** Per-DOM-node hydrated entry, keyed by backendNodeId. */
+export interface DomEntry {
+  backendNodeId: number;
+  frameId: string;
+  parentBackendNodeId: number | null;
+  tag: string;                 // lowercase, e.g. 'div', 'button'
+  attributes: Record<string, string>;
+  bounds: { x: number; y: number; width: number; height: number } | null;
+  cursorStyle: string | null;
+  isClickable: boolean;
+  nodeType: number;            // 1=element, 3=text
+  nodeValue: string | null;    // text content for text nodes
+}
+
+export type DomLookup = Map<number, DomEntry>;
+
+/** Hydrated pipeline data passed to merge. */
+export interface HydratedData {
+  frames: RawFrameAX[];
+  domLookup: DomLookup;
+  /** frameId -> frameUrl, populated from RawFrameAX */
+  frameUrlByFrameId: Map<string, string>;
+  /** Main frameId, used to decide frameUrl=undefined for main frame. */
+  mainFrameId: string;
+}
+
 /** Node after merge stage — ready for filtering and output. */
 export interface MergedNode {
   uid: string;
-  axNode: any; // Original CDP AXNode
+  axNode: any | null;          // null for inferred-injected nodes
   backendNodeId: number | null;
-  frameId: string; // frame that owns this node (for scoped child lookup)
+  frameId: string;
   frameUrl: string | undefined; // undefined for main frame
+  /** Set when an existing AX node's role/name is rewritten by ClickableElementDetector. */
+  upgrade?: { role: string; name: string };
+  /** Set when a node is created from DOM data alone (no corresponding AX node). */
+  inferred?: { role: string; name: string };
 }
 
 /** Limits for iframe traversal to defend against malicious pages. */

--- a/packages/runtime/src/internal/primitives/snapshot/types.ts
+++ b/packages/runtime/src/internal/primitives/snapshot/types.ts
@@ -60,3 +60,13 @@ export interface MergedNode {
 /** Limits for iframe traversal to defend against malicious pages. */
 export const MAX_IFRAME_DEPTH = 5;
 export const MAX_IFRAMES = 100;
+
+export interface MergeResult {
+  nodes: MergedNode[];
+  uidToBackendNodeId: Map<string, number>;
+  axIdToUid: Map<string, string>;
+  /** backendNodeId -> AX node, populated for nodes that survived shouldSkipNode and have backendDOMNodeId. */
+  axNodeByBackendId: Map<number, any>;
+  /** backendNodeId -> uid, reverse of uidToBackendNodeId (built once for M2 join). */
+  backendIdToUid: Map<number, string>;
+}

--- a/tests/unit/primitives-public-api.test.ts
+++ b/tests/unit/primitives-public-api.test.ts
@@ -5,7 +5,10 @@ import { createSecurePuppeteerPrimitives } from '../../src/primitives/factory.js
 function createMockPage(): Page {
   return {
     goto: vi.fn().mockResolvedValue(null),
-    evaluate: vi.fn().mockResolvedValue('ok'),
+    evaluate: vi.fn().mockImplementation((expr: string) => {
+      if (expr === 'window.devicePixelRatio') return Promise.resolve(1);
+      return Promise.resolve('ok');
+    }),
     screenshot: vi.fn().mockResolvedValue(Buffer.from('png')),
     on: vi.fn(),
     off: vi.fn(),
@@ -74,10 +77,13 @@ describe('root primitives public API', () => {
   });
 
   it('builds snapshot nodes from the AX tree through the page-scoped backend', async () => {
-    const send = vi.fn().mockImplementation((method: string) => {
+    const send = vi.fn().mockImplementation((method: string, params?: any) => {
       if (method === 'Browser.getWindowForTarget') return Promise.resolve({ windowId: 1 });
       if (method === 'Browser.getWindowBounds') {
         return Promise.resolve({ bounds: { windowState: 'normal' } });
+      }
+      if (method === 'Page.getFrameTree') {
+        return Promise.resolve({ frameTree: { frame: { id: 'main', url: 'https://x.com/home', securityOrigin: 'https://x.com' } } });
       }
       if (method === 'Accessibility.getFullAXTree') {
         return Promise.resolve({
@@ -91,6 +97,7 @@ describe('root primitives public API', () => {
           }],
         });
       }
+      if (method === 'DOMSnapshot.captureSnapshot') return Promise.resolve({ documents: [], strings: [] });
       return Promise.resolve({});
     });
 

--- a/tests/unit/puppeteer-backend.test.ts
+++ b/tests/unit/puppeteer-backend.test.ts
@@ -30,7 +30,10 @@ vi.mock('../../packages/runtime/src/internal/primitives/click-enhanced.js', () =
 // --- Mocks ---
 
 const mockGoto = vi.fn().mockResolvedValue(undefined);
-const mockEvaluate = vi.fn().mockResolvedValue('result');
+const mockEvaluate = vi.fn().mockImplementation((expr: string) => {
+  if (expr === 'window.devicePixelRatio') return Promise.resolve(1);
+  return Promise.resolve('result');
+});
 const mockScreenshot = vi.fn().mockResolvedValue(Buffer.from('png'));
 const mockAuthenticate = vi.fn().mockResolvedValue(undefined);
 const mockClose = vi.fn().mockResolvedValue(undefined);
@@ -135,6 +138,7 @@ describe('PuppeteerBackend', () => {
           if (method === 'Accessibility.getFullAXTree') {
             return Promise.resolve({ nodes: [{ nodeId: 'ax-1', role: { value: 'button' }, name: { value: 'OK' }, backendDOMNodeId: 101, ignored: false, properties: [] }] });
           }
+          if (method === 'DOMSnapshot.captureSnapshot') return Promise.resolve({ documents: [], strings: [] });
           if (method === 'DOM.describeNode') return Promise.resolve({ node: { nodeId: 10 } });
           if (method === 'DOM.getBoxModel') return Promise.resolve({ model: { content: [100, 200, 200, 200, 200, 240, 100, 240] } });
           return Promise.resolve({});
@@ -323,6 +327,9 @@ describe('PuppeteerBackend', () => {
           if (method === 'Accessibility.getFullAXTree') {
             return Promise.resolve({ nodes });
           }
+          if (method === 'DOMSnapshot.captureSnapshot') {
+            return Promise.resolve({ documents: [], strings: [] });
+          }
           return Promise.resolve({});
         }),
         detach: vi.fn().mockResolvedValue(undefined),
@@ -501,6 +508,7 @@ describe('PuppeteerBackend', () => {
               ],
             });
           }
+          if (method === 'DOMSnapshot.captureSnapshot') return Promise.resolve({ documents: [], strings: [] });
           if (method === 'DOM.describeNode') {
             return Promise.resolve({ node: { nodeId: 10 } });
           }
@@ -570,6 +578,7 @@ describe('PuppeteerBackend', () => {
           if (method === 'Accessibility.getFullAXTree') {
             return Promise.resolve({ nodes: [{ nodeId: 'ax-1', role: { value: 'button' }, name: { value: 'Follow' }, backendDOMNodeId: 101, ignored: false, properties: [] }] });
           }
+          if (method === 'DOMSnapshot.captureSnapshot') return Promise.resolve({ documents: [], strings: [] });
           if (method === 'DOM.describeNode') return Promise.resolve({ node: { nodeId: 10 } });
           if (method === 'DOM.getBoxModel') return Promise.resolve({ model: { content: [100, 200, 200, 200, 200, 240, 100, 240] } });
           if (method === 'Runtime.evaluate') return Promise.resolve({ result: { value: 'visible' } });
@@ -611,6 +620,7 @@ describe('PuppeteerBackend', () => {
           if (method === 'Accessibility.getFullAXTree') {
             return Promise.resolve({ nodes: [{ nodeId: 'ax-1', role: { value: 'button' }, name: { value: 'Follow' }, backendDOMNodeId: 101, ignored: false, properties: [] }] });
           }
+          if (method === 'DOMSnapshot.captureSnapshot') return Promise.resolve({ documents: [], strings: [] });
           if (method === 'DOM.describeNode') return Promise.resolve({ node: { nodeId: 10 } });
           if (method === 'DOM.getBoxModel') return Promise.resolve({ model: { content: [100, 200, 200, 200, 200, 240, 100, 240] } });
           if (method === 'Runtime.evaluate') return Promise.resolve({ result: { value: 'visible' } });
@@ -651,6 +661,7 @@ describe('PuppeteerBackend', () => {
           if (method === 'Accessibility.getFullAXTree') {
             return Promise.resolve({ nodes: [{ nodeId: 'ax-1', role: { value: 'button' }, name: { value: 'Follow' }, backendDOMNodeId: 101, ignored: false, properties: [] }] });
           }
+          if (method === 'DOMSnapshot.captureSnapshot') return Promise.resolve({ documents: [], strings: [] });
           if (method === 'DOM.describeNode') return Promise.resolve({ node: { nodeId: 10 } });
           if (method === 'DOM.getBoxModel') return Promise.resolve({ model: { content: [100, 200, 200, 200, 200, 240, 100, 240] } });
           if (method === 'Runtime.evaluate') return Promise.resolve({ result: { value: 'hidden' } });
@@ -692,6 +703,7 @@ describe('PuppeteerBackend', () => {
           if (method === 'Accessibility.getFullAXTree') {
             return Promise.resolve({ nodes: [{ nodeId: 'ax-1', role: { value: 'button' }, name: { value: 'Follow' }, backendDOMNodeId: 101, ignored: false, properties: [] }] });
           }
+          if (method === 'DOMSnapshot.captureSnapshot') return Promise.resolve({ documents: [], strings: [] });
           if (method === 'DOM.describeNode') return Promise.resolve({ node: { nodeId: 10 } });
           if (method === 'DOM.getBoxModel') return Promise.resolve({ model: { content: [100, 200, 200, 200, 200, 240, 100, 240] } });
           if (method === 'Browser.getWindowForTarget') return Promise.resolve({ windowId: 1 });
@@ -749,6 +761,7 @@ describe('PuppeteerBackend', () => {
           if (method === 'Accessibility.getFullAXTree') {
             return Promise.resolve({ nodes: [{ nodeId: 'ax-1', role: { value: 'button' }, name: { value: 'Follow' }, backendDOMNodeId: 101, ignored: false, properties: [] }] });
           }
+          if (method === 'DOMSnapshot.captureSnapshot') return Promise.resolve({ documents: [], strings: [] });
           if (method === 'DOM.describeNode') return Promise.resolve({ node: { nodeId: 10 } });
           if (method === 'DOM.getBoxModel') return Promise.resolve({ model: { content: [100, 200, 200, 200, 200, 240, 100, 240] } });
           if (method === 'Runtime.evaluate') return Promise.resolve({ result: { value: 'visible' } });
@@ -788,6 +801,7 @@ describe('PuppeteerBackend', () => {
           if (method === 'Accessibility.getFullAXTree') {
             return Promise.resolve({ nodes: [{ nodeId: 'ax-1', role: { value: 'button' }, name: { value: 'Follow' }, backendDOMNodeId: 101, ignored: false, properties: [] }] });
           }
+          if (method === 'DOMSnapshot.captureSnapshot') return Promise.resolve({ documents: [], strings: [] });
           if (method === 'DOM.describeNode') return Promise.resolve({ node: { nodeId: 10 } });
           if (method === 'DOM.getBoxModel') return Promise.resolve({ model: { content: [100, 200, 200, 200, 200, 240, 100, 240] } });
           return Promise.resolve({});
@@ -1117,6 +1131,7 @@ describe('PuppeteerBackend', () => {
               ],
             });
           }
+          if (method === 'DOMSnapshot.captureSnapshot') return Promise.resolve({ documents: [], strings: [] });
           if (method === 'DOM.focus') {
             return Promise.resolve({});
           }
@@ -1167,6 +1182,7 @@ describe('PuppeteerBackend', () => {
               }],
             });
           }
+          if (method === 'DOMSnapshot.captureSnapshot') return Promise.resolve({ documents: [], strings: [] });
           if (method === 'DOM.focus') {
             return Promise.reject(new Error('Could not find node'));
           }
@@ -1407,6 +1423,7 @@ describe('PuppeteerBackend', () => {
               ],
             });
           }
+          if (method === 'DOMSnapshot.captureSnapshot') return Promise.resolve({ documents: [], strings: [] });
           return Promise.resolve({});
         }),
         detach: vi.fn().mockResolvedValue(undefined),

--- a/tests/unit/snapshot-clickable-detector.test.ts
+++ b/tests/unit/snapshot-clickable-detector.test.ts
@@ -81,4 +81,21 @@ describe('ClickableElementDetector.isInteractive', () => {
       expect(ClickableElementDetector.isInteractive(makeEntry({ tag: 'div' }), ax, empty)).toBe(true);
     }
   });
+
+  it('onclick attribute marks interactive', () => {
+    expect(ClickableElementDetector.isInteractive(makeEntry({ tag: 'div', attributes: { onclick: 'foo()' } }), null, empty)).toBe(true);
+  });
+
+  it('tabindex attribute marks interactive', () => {
+    expect(ClickableElementDetector.isInteractive(makeEntry({ tag: 'div', attributes: { tabindex: '0' } }), null, empty)).toBe(true);
+  });
+
+  it('role="button" attribute marks interactive', () => {
+    expect(ClickableElementDetector.isInteractive(makeEntry({ tag: 'div', attributes: { role: 'button' } }), null, empty)).toBe(true);
+  });
+
+  it('AX role=link marks interactive', () => {
+    const ax = { role: { value: 'link' }, properties: [] };
+    expect(ClickableElementDetector.isInteractive(makeEntry({ tag: 'div' }), ax, empty)).toBe(true);
+  });
 });

--- a/tests/unit/snapshot-clickable-detector.test.ts
+++ b/tests/unit/snapshot-clickable-detector.test.ts
@@ -41,4 +41,19 @@ describe('ClickableElementDetector.isInteractive', () => {
   it('plain div with no signals is NOT interactive', () => {
     expect(ClickableElementDetector.isInteractive(makeEntry({ tag: 'div' }), null, empty)).toBe(false);
   });
+
+  it('isClickable=true marks div as interactive (DOMSnapshot click-listener signal)', () => {
+    const e = makeEntry({ tag: 'div', isClickable: true });
+    expect(ClickableElementDetector.isInteractive(e, null, empty)).toBe(true);
+  });
+
+  it('cursor:pointer fallback marks div as interactive', () => {
+    const e = makeEntry({ tag: 'div', cursorStyle: 'pointer' });
+    expect(ClickableElementDetector.isInteractive(e, null, empty)).toBe(true);
+  });
+
+  it('cursor:default on plain div does not trigger', () => {
+    const e = makeEntry({ tag: 'div', cursorStyle: 'default' });
+    expect(ClickableElementDetector.isInteractive(e, null, empty)).toBe(false);
+  });
 });

--- a/tests/unit/snapshot-clickable-detector.test.ts
+++ b/tests/unit/snapshot-clickable-detector.test.ts
@@ -98,4 +98,26 @@ describe('ClickableElementDetector.isInteractive', () => {
     const ax = { role: { value: 'link' }, properties: [] };
     expect(ClickableElementDetector.isInteractive(makeEntry({ tag: 'div' }), ax, empty)).toBe(true);
   });
+
+  it('search indicator in class marks interactive', () => {
+    expect(ClickableElementDetector.isInteractive(makeEntry({ tag: 'div', attributes: { class: 'search-btn primary' } }), null, empty)).toBe(true);
+  });
+
+  it('search indicator in id marks interactive', () => {
+    expect(ClickableElementDetector.isInteractive(makeEntry({ tag: 'div', attributes: { id: 'magnify-glass' } }), null, empty)).toBe(true);
+  });
+
+  it('search indicator in data-* marks interactive', () => {
+    expect(ClickableElementDetector.isInteractive(makeEntry({ tag: 'div', attributes: { 'data-action': 'lookup' } }), null, empty)).toBe(true);
+  });
+
+  it('icon-sized element with class attr marks interactive', () => {
+    const e = makeEntry({ tag: 'span', bounds: { x: 0, y: 0, width: 24, height: 24 }, attributes: { class: 'icon close' } });
+    expect(ClickableElementDetector.isInteractive(e, null, empty)).toBe(true);
+  });
+
+  it('icon-sized element with no relevant attrs is not interactive', () => {
+    const e = makeEntry({ tag: 'span', bounds: { x: 0, y: 0, width: 24, height: 24 }, attributes: { lang: 'en' } });
+    expect(ClickableElementDetector.isInteractive(e, null, empty)).toBe(false);
+  });
 });

--- a/tests/unit/snapshot-clickable-detector.test.ts
+++ b/tests/unit/snapshot-clickable-detector.test.ts
@@ -150,4 +150,28 @@ describe('ClickableElementDetector.isInteractive', () => {
     lookup.set(1, span); lookup.set(2, input);
     expect(ClickableElementDetector.isInteractive(span, null, lookup)).toBe(true);
   });
+
+  // DOM-level disabled gate — covers AX-orphan path that AX disabled gate misses.
+  // M2 specifically targets Vue/React divs AX dropped, so axNode is null and the
+  // earlier AX disabled check never fires for them.
+
+  it('AX-orphan div with aria-disabled="true" + cursor:pointer is NOT interactive', () => {
+    const e = makeEntry({ tag: 'div', cursorStyle: 'pointer', attributes: { 'aria-disabled': 'true' } });
+    expect(ClickableElementDetector.isInteractive(e, null, empty)).toBe(false);
+  });
+
+  it('AX-orphan div with aria-disabled="" (boolean shorthand) is NOT interactive', () => {
+    const e = makeEntry({ tag: 'div', isClickable: true, attributes: { 'aria-disabled': '' } });
+    expect(ClickableElementDetector.isInteractive(e, null, empty)).toBe(false);
+  });
+
+  it('AX-orphan div with disabled attribute + isClickable is NOT interactive', () => {
+    const e = makeEntry({ tag: 'div', isClickable: true, attributes: { disabled: '' } });
+    expect(ClickableElementDetector.isInteractive(e, null, empty)).toBe(false);
+  });
+
+  it('aria-disabled="false" does not block — control case', () => {
+    const e = makeEntry({ tag: 'div', cursorStyle: 'pointer', attributes: { 'aria-disabled': 'false' } });
+    expect(ClickableElementDetector.isInteractive(e, null, empty)).toBe(true);
+  });
 });

--- a/tests/unit/snapshot-clickable-detector.test.ts
+++ b/tests/unit/snapshot-clickable-detector.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { ClickableElementDetector } from '../../packages/runtime/src/internal/primitives/snapshot/clickable-detector.js';
+import type { DomEntry, DomLookup } from '../../packages/runtime/src/internal/primitives/snapshot/types.js';
+
+function makeEntry(partial: Partial<DomEntry>): DomEntry {
+  return {
+    backendNodeId: 1, frameId: 'main', parentBackendNodeId: null,
+    tag: 'div', attributes: {}, bounds: null, cursorStyle: null,
+    isClickable: false, nodeType: 1, nodeValue: null,
+    ...partial,
+  };
+}
+const empty: DomLookup = new Map();
+
+describe('ClickableElementDetector.isInteractive', () => {
+  it('skips html and body', () => {
+    expect(ClickableElementDetector.isInteractive(makeEntry({ tag: 'html' }), null, empty)).toBe(false);
+    expect(ClickableElementDetector.isInteractive(makeEntry({ tag: 'body' }), null, empty)).toBe(false);
+  });
+
+  it('skips non-element nodes', () => {
+    expect(ClickableElementDetector.isInteractive(makeEntry({ nodeType: 3 }), null, empty)).toBe(false);
+  });
+
+  it('matches interactive_tags', () => {
+    for (const tag of ['button', 'input', 'select', 'textarea', 'a', 'details', 'summary', 'option', 'optgroup']) {
+      expect(ClickableElementDetector.isInteractive(makeEntry({ tag }), null, empty)).toBe(true);
+    }
+  });
+
+  it('iframe ≥100×100 is interactive', () => {
+    const big = makeEntry({ tag: 'iframe', bounds: { x: 0, y: 0, width: 200, height: 200 } });
+    expect(ClickableElementDetector.isInteractive(big, null, empty)).toBe(true);
+  });
+
+  it('iframe <100×100 is NOT interactive', () => {
+    const small = makeEntry({ tag: 'iframe', bounds: { x: 0, y: 0, width: 50, height: 50 } });
+    expect(ClickableElementDetector.isInteractive(small, null, empty)).toBe(false);
+  });
+
+  it('plain div with no signals is NOT interactive', () => {
+    expect(ClickableElementDetector.isInteractive(makeEntry({ tag: 'div' }), null, empty)).toBe(false);
+  });
+});

--- a/tests/unit/snapshot-clickable-detector.test.ts
+++ b/tests/unit/snapshot-clickable-detector.test.ts
@@ -56,4 +56,29 @@ describe('ClickableElementDetector.isInteractive', () => {
     const e = makeEntry({ tag: 'div', cursorStyle: 'default' });
     expect(ClickableElementDetector.isInteractive(e, null, empty)).toBe(false);
   });
+
+  it('AX disabled excludes even when other signals fire', () => {
+    const e = makeEntry({ tag: 'div', cursorStyle: 'pointer' });
+    const ax = { properties: [{ name: 'disabled', value: { value: true } }] };
+    expect(ClickableElementDetector.isInteractive(e, ax, empty)).toBe(false);
+  });
+
+  it('AX hidden excludes', () => {
+    const e = makeEntry({ tag: 'button' });
+    const ax = { properties: [{ name: 'hidden', value: { value: true } }] };
+    expect(ClickableElementDetector.isInteractive(e, ax, empty)).toBe(false);
+  });
+
+  it('AX focusable=true marks interactive', () => {
+    const e = makeEntry({ tag: 'div' });
+    const ax = { properties: [{ name: 'focusable', value: { value: true } }] };
+    expect(ClickableElementDetector.isInteractive(e, ax, empty)).toBe(true);
+  });
+
+  it('AX checked/expanded/pressed/selected presence marks interactive', () => {
+    for (const name of ['checked', 'expanded', 'pressed', 'selected']) {
+      const ax = { properties: [{ name, value: { value: false } }] };
+      expect(ClickableElementDetector.isInteractive(makeEntry({ tag: 'div' }), ax, empty)).toBe(true);
+    }
+  });
 });

--- a/tests/unit/snapshot-clickable-detector.test.ts
+++ b/tests/unit/snapshot-clickable-detector.test.ts
@@ -120,4 +120,34 @@ describe('ClickableElementDetector.isInteractive', () => {
     const e = makeEntry({ tag: 'span', bounds: { x: 0, y: 0, width: 24, height: 24 }, attributes: { lang: 'en' } });
     expect(ClickableElementDetector.isInteractive(e, null, empty)).toBe(false);
   });
+
+  it('label[for=...] is NOT interactive (proxies external input)', () => {
+    const e = makeEntry({ tag: 'label', attributes: { for: 'email' } });
+    expect(ClickableElementDetector.isInteractive(e, null, empty)).toBe(false);
+  });
+
+  it('label > input is interactive (no for attr)', () => {
+    const lookup: DomLookup = new Map();
+    const label: DomEntry = makeEntry({ backendNodeId: 1, tag: 'label' });
+    const input: DomEntry = makeEntry({ backendNodeId: 2, tag: 'input', parentBackendNodeId: 1 });
+    lookup.set(1, label); lookup.set(2, input);
+    expect(ClickableElementDetector.isInteractive(label, null, lookup)).toBe(true);
+  });
+
+  it('label > span > input is interactive (depth 2)', () => {
+    const lookup: DomLookup = new Map();
+    const label = makeEntry({ backendNodeId: 1, tag: 'label' });
+    const span  = makeEntry({ backendNodeId: 2, tag: 'span', parentBackendNodeId: 1 });
+    const input = makeEntry({ backendNodeId: 3, tag: 'input', parentBackendNodeId: 2 });
+    lookup.set(1, label); lookup.set(2, span); lookup.set(3, input);
+    expect(ClickableElementDetector.isInteractive(label, null, lookup)).toBe(true);
+  });
+
+  it('span > input is interactive', () => {
+    const lookup: DomLookup = new Map();
+    const span = makeEntry({ backendNodeId: 1, tag: 'span' });
+    const input = makeEntry({ backendNodeId: 2, tag: 'input', parentBackendNodeId: 1 });
+    lookup.set(1, span); lookup.set(2, input);
+    expect(ClickableElementDetector.isInteractive(span, null, lookup)).toBe(true);
+  });
 });

--- a/tests/unit/snapshot-derive-name.test.ts
+++ b/tests/unit/snapshot-derive-name.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { deriveDomName } from '../../packages/runtime/src/internal/primitives/snapshot/derive-name.js';
+import type { DomEntry, DomLookup } from '../../packages/runtime/src/internal/primitives/snapshot/types.js';
+
+function makeEntry(p: Partial<DomEntry>): DomEntry {
+  return {
+    backendNodeId: 1, frameId: 'main', parentBackendNodeId: null,
+    tag: 'div', attributes: {}, bounds: null, cursorStyle: null,
+    isClickable: false, nodeType: 1, nodeValue: null, ...p,
+  };
+}
+
+describe('deriveDomName', () => {
+  it('aria-label wins over title', () => {
+    const e = makeEntry({ attributes: { 'aria-label': 'Send', title: 'Submit' } });
+    expect(deriveDomName(e, new Map())).toBe('Send');
+  });
+
+  it('title fallback when no aria-label', () => {
+    const e = makeEntry({ attributes: { title: 'Hello' } });
+    expect(deriveDomName(e, new Map())).toBe('Hello');
+  });
+
+  it('placeholder fallback when no aria/title/text', () => {
+    const e = makeEntry({ attributes: { placeholder: 'Search…' } });
+    expect(deriveDomName(e, new Map())).toBe('Search…');
+  });
+
+  it('returns empty string when nothing available', () => {
+    expect(deriveDomName(makeEntry({}), new Map())).toBe('');
+  });
+
+  it('trims whitespace', () => {
+    const e = makeEntry({ attributes: { 'aria-label': '   Click me   ' } });
+    expect(deriveDomName(e, new Map())).toBe('Click me');
+  });
+
+  it('truncates strings >80 chars with ellipsis', () => {
+    const long = 'a'.repeat(100);
+    const e = makeEntry({ attributes: { title: long } });
+    const out = deriveDomName(e, new Map());
+    expect(out.length).toBe(81);
+    expect(out.endsWith('…')).toBe(true);
+  });
+});

--- a/tests/unit/snapshot-derive-name.test.ts
+++ b/tests/unit/snapshot-derive-name.test.ts
@@ -42,4 +42,31 @@ describe('deriveDomName', () => {
     expect(out.length).toBe(81);
     expect(out.endsWith('…')).toBe(true);
   });
+
+  it('aggregates direct text child', () => {
+    const lookup: DomLookup = new Map();
+    const div = makeEntry({ backendNodeId: 1, tag: 'div' });
+    const text = makeEntry({ backendNodeId: 2, parentBackendNodeId: 1, nodeType: 3, nodeValue: '页面价 ▾' });
+    lookup.set(1, div); lookup.set(2, text);
+    expect(deriveDomName(div, lookup)).toBe('页面价 ▾');
+  });
+
+  it('aggregates nested text descendants in document order', () => {
+    const lookup: DomLookup = new Map();
+    const div   = makeEntry({ backendNodeId: 1, tag: 'div' });
+    const span1 = makeEntry({ backendNodeId: 2, tag: 'span', parentBackendNodeId: 1 });
+    const t1    = makeEntry({ backendNodeId: 3, parentBackendNodeId: 2, nodeType: 3, nodeValue: 'Hello ' });
+    const span2 = makeEntry({ backendNodeId: 4, tag: 'span', parentBackendNodeId: 1 });
+    const t2    = makeEntry({ backendNodeId: 5, parentBackendNodeId: 4, nodeType: 3, nodeValue: 'World' });
+    lookup.set(1, div); lookup.set(2, span1); lookup.set(3, t1); lookup.set(4, span2); lookup.set(5, t2);
+    expect(deriveDomName(div, lookup)).toBe('Hello World');
+  });
+
+  it('aria-label still wins over text content', () => {
+    const lookup: DomLookup = new Map();
+    const div = makeEntry({ backendNodeId: 1, tag: 'div', attributes: { 'aria-label': 'Real Name' } });
+    const text = makeEntry({ backendNodeId: 2, parentBackendNodeId: 1, nodeType: 3, nodeValue: 'visible text' });
+    lookup.set(1, div); lookup.set(2, text);
+    expect(deriveDomName(div, lookup)).toBe('Real Name');
+  });
 });

--- a/tests/unit/snapshot-fetch-dom.test.ts
+++ b/tests/unit/snapshot-fetch-dom.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchSnapshotData } from '../../packages/runtime/src/internal/primitives/snapshot/fetch.js';
+
+describe('fetchSnapshotData', () => {
+  it('returns frames + domSnapshot from parallel CDP calls', async () => {
+    const session = {
+      send: vi.fn().mockImplementation((method: string) => {
+        if (method === 'Page.getFrameTree') {
+          return Promise.resolve({
+            frameTree: { frame: { id: 'main', url: 'https://x.com', securityOrigin: 'https://x.com' } },
+          });
+        }
+        if (method === 'Accessibility.getFullAXTree') {
+          return Promise.resolve({ nodes: [{ nodeId: 'a1', role: { value: 'button' }, name: { value: 'X' }, backendDOMNodeId: 1, ignored: false }] });
+        }
+        if (method === 'DOMSnapshot.captureSnapshot') {
+          return Promise.resolve({ documents: [{ frame: 'main', nodes: { backendNodeId: [1] } }], strings: ['BUTTON'] });
+        }
+        return Promise.resolve({});
+      }),
+    };
+
+    const result = await fetchSnapshotData(session as any);
+    expect(result.frames.length).toBe(1);
+    expect(result.frames[0].frameId).toBe('main');
+    expect(result.domSnapshot.documents.length).toBe(1);
+    expect(result.domSnapshot.strings).toEqual(['BUTTON']);
+  });
+
+  it('degrades gracefully when DOMSnapshot.captureSnapshot fails', async () => {
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const session = {
+      send: vi.fn().mockImplementation((method: string) => {
+        if (method === 'Page.getFrameTree') {
+          return Promise.resolve({ frameTree: { frame: { id: 'main', url: '', securityOrigin: 'x' } } });
+        }
+        if (method === 'Accessibility.getFullAXTree') return Promise.resolve({ nodes: [] });
+        if (method === 'DOMSnapshot.captureSnapshot') return Promise.reject(new Error('not supported'));
+        return Promise.resolve({});
+      }),
+    };
+
+    const result = await fetchSnapshotData(session as any);
+    expect(result.domSnapshot.documents).toEqual([]);
+    expect(result.domSnapshot.strings).toEqual([]);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/unit/snapshot-hydrate-dom.test.ts
+++ b/tests/unit/snapshot-hydrate-dom.test.ts
@@ -94,4 +94,55 @@ describe('hydrateDomSnapshot', () => {
     expect(entry.bounds).toEqual({ x: 50, y: 100, width: 150, height: 200 });
     expect(entry.cursorStyle).toBe('pointer');
   });
+
+  it('decodes text nodes with nodeValue', () => {
+    const snapshot: RawDomSnapshot = {
+      strings: ['DIV', '#text', 'Hello World'],
+      documents: [{
+        frame: 'main',
+        nodes: {
+          parentIndex: [-1, 0],
+          nodeType: [1, 3],
+          nodeName: [0, 1],
+          nodeValue: [-1, 2],
+          backendNodeId: [50, 51],
+          attributes: [[], []],
+          isClickable: { index: [] },
+        },
+        layout: { nodeIndex: [], bounds: [], styles: [] },
+      }],
+    };
+    const result = hydrateDomSnapshot(snapshot, 1);
+    const text = result.get(51)!;
+    expect(text.nodeType).toBe(3);
+    expect(text.nodeValue).toBe('Hello World');
+    expect(text.parentBackendNodeId).toBe(50);
+  });
+
+  it('multi-document: each entry tagged with its document frameId', () => {
+    const snapshot: RawDomSnapshot = {
+      strings: ['DIV'],
+      documents: [
+        {
+          frame: 'main',
+          nodes: {
+            parentIndex: [-1], nodeType: [1], nodeName: [0], nodeValue: [-1],
+            backendNodeId: [100], attributes: [[]], isClickable: { index: [] },
+          },
+          layout: { nodeIndex: [], bounds: [], styles: [] },
+        },
+        {
+          frame: 'iframe-1',
+          nodes: {
+            parentIndex: [-1], nodeType: [1], nodeName: [0], nodeValue: [-1],
+            backendNodeId: [200], attributes: [[]], isClickable: { index: [] },
+          },
+          layout: { nodeIndex: [], bounds: [], styles: [] },
+        },
+      ],
+    };
+    const result = hydrateDomSnapshot(snapshot, 1);
+    expect(result.get(100)!.frameId).toBe('main');
+    expect(result.get(200)!.frameId).toBe('iframe-1');
+  });
 });

--- a/tests/unit/snapshot-hydrate-dom.test.ts
+++ b/tests/unit/snapshot-hydrate-dom.test.ts
@@ -43,4 +43,55 @@ describe('hydrateDomSnapshot', () => {
     const html = result.get(10)!;
     expect(html.parentBackendNodeId).toBeNull();
   });
+
+  it('decodes isClickable RareBooleanData (sparse hits)', () => {
+    const snapshot: RawDomSnapshot = {
+      strings: ['DIV'],
+      documents: [{
+        frame: 'main',
+        nodes: {
+          parentIndex: [-1, 0, 0, 0],
+          nodeType: [1, 1, 1, 1],
+          nodeName: [0, 0, 0, 0],
+          nodeValue: [-1, -1, -1, -1],
+          backendNodeId: [1, 2, 3, 4],
+          attributes: [[], [], [], []],
+          isClickable: { index: [1, 3] },
+        },
+        layout: { nodeIndex: [], bounds: [], styles: [] },
+      }],
+    };
+    const result = hydrateDomSnapshot(snapshot, 1);
+    expect(result.get(1)!.isClickable).toBe(false);
+    expect(result.get(2)!.isClickable).toBe(true);
+    expect(result.get(3)!.isClickable).toBe(false);
+    expect(result.get(4)!.isClickable).toBe(true);
+  });
+
+  it('decodes layout bounds with devicePixelRatio scaling and cursor style', () => {
+    const snapshot: RawDomSnapshot = {
+      strings: ['DIV', 'pointer'],
+      documents: [{
+        frame: 'main',
+        nodes: {
+          parentIndex: [-1],
+          nodeType: [1],
+          nodeName: [0],
+          nodeValue: [-1],
+          backendNodeId: [99],
+          attributes: [[]],
+          isClickable: { index: [] },
+        },
+        layout: {
+          nodeIndex: [0],
+          bounds: [[100, 200, 300, 400]],
+          styles: [[1]],
+        },
+      }],
+    };
+    const result = hydrateDomSnapshot(snapshot, 2);
+    const entry = result.get(99)!;
+    expect(entry.bounds).toEqual({ x: 50, y: 100, width: 150, height: 200 });
+    expect(entry.cursorStyle).toBe('pointer');
+  });
 });

--- a/tests/unit/snapshot-hydrate-dom.test.ts
+++ b/tests/unit/snapshot-hydrate-dom.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { hydrateDomSnapshot } from '../../packages/runtime/src/internal/primitives/snapshot/hydrate.js';
+import type { RawDomSnapshot } from '../../packages/runtime/src/internal/primitives/snapshot/types.js';
+
+describe('hydrateDomSnapshot', () => {
+  it('empty input → empty lookup', () => {
+    const result = hydrateDomSnapshot({ documents: [], strings: [] }, 1);
+    expect(result.size).toBe(0);
+  });
+
+  it('single document — decodes backendNodeId, tag, attributes, parentIndex', () => {
+    const snapshot: RawDomSnapshot = {
+      strings: ['HTML', 'BODY', 'DIV', 'id', 'root', 'class', 'card'],
+      documents: [{
+        frame: 'main-frame',
+        nodes: {
+          parentIndex: [-1, 0, 1],
+          nodeType: [1, 1, 1],
+          nodeName: [0, 1, 2],
+          nodeValue: [-1, -1, -1],
+          backendNodeId: [10, 11, 12],
+          attributes: [
+            [],
+            [],
+            [3, 4, 5, 6],
+          ],
+          isClickable: { index: [] },
+        },
+        layout: { nodeIndex: [], bounds: [], styles: [] },
+      }],
+    };
+    const result = hydrateDomSnapshot(snapshot, 1);
+
+    expect(result.size).toBe(3);
+    const div = result.get(12)!;
+    expect(div.backendNodeId).toBe(12);
+    expect(div.tag).toBe('div');
+    expect(div.attributes).toEqual({ id: 'root', class: 'card' });
+    expect(div.parentBackendNodeId).toBe(11);
+    expect(div.frameId).toBe('main-frame');
+    expect(div.nodeType).toBe(1);
+
+    const html = result.get(10)!;
+    expect(html.parentBackendNodeId).toBeNull();
+  });
+});

--- a/tests/unit/snapshot-integration.test.ts
+++ b/tests/unit/snapshot-integration.test.ts
@@ -125,4 +125,83 @@ describe('takeSnapshot pipeline integration', () => {
     expect(snapshot.idToNode.size).toBe(1);
     expect(snapshot.idToNode.get('1')!.name).toBe('OK');
   });
+
+  it('M2: Vue-style <div @click> appears as inferred button', async () => {
+    const { page } = createMockPageWithFrames(
+      { frame: { id: 'main', url: 'https://qly.example/', securityOrigin: 'https://qly.example' } },
+      {
+        main: [
+          { nodeId: 'a1', role: { value: 'generic' }, name: { value: '' }, backendDOMNodeId: 100, ignored: false, properties: [] },
+        ],
+      },
+      {
+        documents: [{
+          frame: 'main',
+          nodes: {
+            parentIndex: [-1, 0],
+            nodeType: [1, 3],
+            nodeName: [0, 1],
+            nodeValue: [-1, 2],
+            backendNodeId: [100, 101],
+            attributes: [[], []],
+            isClickable: { index: [] },
+          },
+          layout: {
+            nodeIndex: [0],
+            bounds: [[10, 20, 100, 30]],
+            styles: [[3]],
+          },
+        }],
+        strings: ['DIV', '#text', 'Filter', 'pointer'],
+      },
+    );
+
+    const backend = new PuppeteerBackend({ page: page as any, siteDomains: { test: ['qly.example'] } });
+    const snapshot = await backend.takeSnapshot();
+
+    expect(snapshot.idToNode.size).toBe(1);
+    const node = snapshot.idToNode.get('1')!;
+    expect(node.role).toBe('button');
+    expect(node.name).toBe('Filter');
+    expect(node.frameUrl).toBeUndefined();
+  });
+
+  it('M2: AX-orphan div with cursor:pointer is injected as inferred button', async () => {
+    const { page } = createMockPageWithFrames(
+      { frame: { id: 'main', url: 'https://qly.example/', securityOrigin: 'https://qly.example' } },
+      {
+        main: [
+          { nodeId: 'a1', role: { value: 'button' }, name: { value: 'Native' }, backendDOMNodeId: 100, ignored: false, properties: [] },
+        ],
+      },
+      {
+        documents: [{
+          frame: 'main',
+          nodes: {
+            parentIndex: [-1, -1],
+            nodeType: [1, 1],
+            nodeName: [0, 0],
+            nodeValue: [-1, -1],
+            backendNodeId: [100, 200],
+            attributes: [[], []],
+            isClickable: { index: [] },
+          },
+          layout: {
+            nodeIndex: [1],
+            bounds: [[0, 0, 80, 40]],
+            styles: [[1]],
+          },
+        }],
+        strings: ['DIV', 'pointer'],
+      },
+    );
+
+    const backend = new PuppeteerBackend({ page: page as any, siteDomains: { test: ['qly.example'] } });
+    const snapshot = await backend.takeSnapshot();
+
+    expect(snapshot.idToNode.size).toBe(2);
+    expect(snapshot.idToNode.get('1')!.name).toBe('Native');
+    const injected = snapshot.idToNode.get('2')!;
+    expect(injected.role).toBe('button');
+  });
 });

--- a/tests/unit/snapshot-integration.test.ts
+++ b/tests/unit/snapshot-integration.test.ts
@@ -15,13 +15,14 @@ vi.mock('../../packages/runtime/src/internal/primitives/click-enhanced.js', () =
 
 import { PuppeteerBackend } from '../../packages/runtime/src/internal/primitives/puppeteer-backend.js';
 
-function createMockPageWithFrames(frameTree: any, axResults: Record<string, any[]>) {
+function createMockPageWithFrames(frameTree: any, axResults: Record<string, any[]>, domSnapshot: any = { documents: [], strings: [] }) {
   const session = {
     send: vi.fn().mockImplementation((method: string, params?: any) => {
       if (method === 'Page.getFrameTree') return Promise.resolve({ frameTree });
       if (method === 'Accessibility.getFullAXTree') {
         return Promise.resolve({ nodes: axResults[params?.frameId] ?? [] });
       }
+      if (method === 'DOMSnapshot.captureSnapshot') return Promise.resolve(domSnapshot);
       return Promise.resolve({});
     }),
     detach: vi.fn().mockResolvedValue(undefined),
@@ -31,7 +32,10 @@ function createMockPageWithFrames(frameTree: any, axResults: Record<string, any[
     url: vi.fn().mockReturnValue('https://example.com'),
     createCDPSession: vi.fn().mockResolvedValue(session),
     bringToFront: vi.fn().mockResolvedValue(undefined),
-    evaluate: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockImplementation((expr: string) => {
+      if (expr === 'window.devicePixelRatio') return Promise.resolve(1);
+      return Promise.resolve(undefined);
+    }),
     on: vi.fn(), off: vi.fn(),
     mouse: { click: vi.fn(), wheel: vi.fn(), move: vi.fn() },
     keyboard: { type: vi.fn(), press: vi.fn(), sendCharacter: vi.fn() },

--- a/tests/unit/snapshot-merge-dom.test.ts
+++ b/tests/unit/snapshot-merge-dom.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { mergeAxData, mergeDomSnapshot } from '../../packages/runtime/src/internal/primitives/snapshot/merge.js';
+import type { DomEntry, DomLookup, RawFrameAX } from '../../packages/runtime/src/internal/primitives/snapshot/types.js';
+
+function ax(nodeId: string, role: string, name: string, backendId: number): any {
+  return { nodeId, role: { value: role }, name: { value: name }, backendDOMNodeId: backendId, ignored: false, properties: [] };
+}
+function dom(p: Partial<DomEntry>): DomEntry {
+  return {
+    backendNodeId: 1, frameId: 'main', parentBackendNodeId: null,
+    tag: 'div', attributes: {}, bounds: null, cursorStyle: null,
+    isClickable: false, nodeType: 1, nodeValue: null, ...p,
+  };
+}
+
+describe('mergeDomSnapshot — upgrade scenario', () => {
+  it('upgrades AX role=generic node when DOM is interactive (cursor:pointer)', () => {
+    const frames: RawFrameAX[] = [{
+      frameId: 'main', frameUrl: 'https://x.com', isMainFrame: true,
+      nodes: [ax('a1', 'generic', '', 100)],
+    }];
+    const base = mergeAxData(frames);
+
+    const domLookup: DomLookup = new Map();
+    const text = dom({ backendNodeId: 200, parentBackendNodeId: 100, nodeType: 3, nodeValue: '页面价 ▾' });
+    const div  = dom({ backendNodeId: 100, tag: 'div', cursorStyle: 'pointer' });
+    domLookup.set(100, div); domLookup.set(200, text);
+
+    const result = mergeDomSnapshot(
+      base, domLookup,
+      new Map([['main', 'https://x.com']]),
+      'main',
+    );
+
+    expect(result.nodes.length).toBe(1);
+    expect(result.nodes[0].uid).toBe('1');
+    expect(result.nodes[0].upgrade).toEqual({ role: 'button', name: '页面价 ▾' });
+  });
+});

--- a/tests/unit/snapshot-merge-dom.test.ts
+++ b/tests/unit/snapshot-merge-dom.test.ts
@@ -37,3 +37,99 @@ describe('mergeDomSnapshot — upgrade scenario', () => {
     expect(result.nodes[0].upgrade).toEqual({ role: 'button', name: '页面价 ▾' });
   });
 });
+
+describe('mergeDomSnapshot — inject scenarios', () => {
+  it('injects new node when AX never saw the backendNodeId (case ②)', () => {
+    const frames: RawFrameAX[] = [{
+      frameId: 'main', frameUrl: 'https://x.com', isMainFrame: true,
+      nodes: [ax('a1', 'button', 'Existing', 100)],
+    }];
+    const base = mergeAxData(frames);
+
+    const domLookup: DomLookup = new Map();
+    const div = dom({ backendNodeId: 999, tag: 'div', cursorStyle: 'pointer' });
+    const text = dom({ backendNodeId: 1000, parentBackendNodeId: 999, nodeType: 3, nodeValue: 'Orphan' });
+    domLookup.set(999, div); domLookup.set(1000, text);
+
+    const result = mergeDomSnapshot(
+      base, domLookup,
+      new Map([['main', 'https://x.com']]),
+      'main',
+    );
+
+    expect(result.nodes.length).toBe(2);
+    const injected = result.nodes.find(n => n.axNode === null)!;
+    expect(injected.uid).toBe('2');
+    expect(injected.backendNodeId).toBe(999);
+    expect(injected.frameUrl).toBeUndefined();
+    expect(injected.inferred).toEqual({ role: 'button', name: 'Orphan' });
+    expect(result.uidToBackendNodeId.get('2')).toBe(999);
+  });
+
+  it('injects when AX dropped node via shouldSkipNode (case ③)', () => {
+    const frames: RawFrameAX[] = [{
+      frameId: 'main', frameUrl: 'https://x.com', isMainFrame: true,
+      nodes: [
+        { nodeId: 'a1', role: { value: 'none' }, name: { value: '' }, backendDOMNodeId: 500, ignored: false, properties: [] },
+      ],
+    }];
+    const base = mergeAxData(frames);
+    expect(base.nodes.length).toBe(0);
+
+    const domLookup: DomLookup = new Map();
+    domLookup.set(500, dom({ backendNodeId: 500, tag: 'div', cursorStyle: 'pointer' }));
+
+    const result = mergeDomSnapshot(
+      base, domLookup,
+      new Map([['main', 'https://x.com']]),
+      'main',
+    );
+
+    expect(result.nodes.length).toBe(1);
+    expect(result.nodes[0].axNode).toBeNull();
+    expect(result.nodes[0].backendNodeId).toBe(500);
+    expect(result.nodes[0].inferred?.role).toBe('button');
+  });
+
+  it('does not modify or duplicate existing AX role=button nodes', () => {
+    const frames: RawFrameAX[] = [{
+      frameId: 'main', frameUrl: 'https://x.com', isMainFrame: true,
+      nodes: [ax('a1', 'button', 'Submit', 100)],
+    }];
+    const base = mergeAxData(frames);
+
+    const domLookup: DomLookup = new Map();
+    domLookup.set(100, dom({ backendNodeId: 100, tag: 'button', cursorStyle: 'pointer' }));
+
+    const result = mergeDomSnapshot(
+      base, domLookup,
+      new Map([['main', 'https://x.com']]),
+      'main',
+    );
+
+    expect(result.nodes.length).toBe(1);
+    expect(result.nodes[0].upgrade).toBeUndefined();
+    expect(result.nodes[0].inferred).toBeUndefined();
+    expect(result.nodes[0].axNode.role.value).toBe('button');
+  });
+
+  it('injected iframe-internal node has correct frameUrl', () => {
+    const frames: RawFrameAX[] = [
+      { frameId: 'main', frameUrl: 'https://x.com', isMainFrame: true, nodes: [] },
+      { frameId: 'iframe-1', frameUrl: 'https://x.com/dialog', isMainFrame: false, nodes: [] },
+    ];
+    const base = mergeAxData(frames);
+
+    const domLookup: DomLookup = new Map();
+    domLookup.set(700, dom({ backendNodeId: 700, frameId: 'iframe-1', tag: 'div', cursorStyle: 'pointer' }));
+
+    const result = mergeDomSnapshot(
+      base, domLookup,
+      new Map([['main', 'https://x.com'], ['iframe-1', 'https://x.com/dialog']]),
+      'main',
+    );
+
+    expect(result.nodes.length).toBe(1);
+    expect(result.nodes[0].frameUrl).toBe('https://x.com/dialog');
+  });
+});

--- a/tests/unit/snapshot-merge-dom.test.ts
+++ b/tests/unit/snapshot-merge-dom.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { mergeAxData, mergeDomSnapshot } from '../../packages/runtime/src/internal/primitives/snapshot/merge.js';
+import { buildSnapshotOutput } from '../../packages/runtime/src/internal/primitives/snapshot/output.js';
 import type { DomEntry, DomLookup, RawFrameAX } from '../../packages/runtime/src/internal/primitives/snapshot/types.js';
 
 function ax(nodeId: string, role: string, name: string, backendId: number): any {
@@ -131,5 +132,43 @@ describe('mergeDomSnapshot — inject scenarios', () => {
 
     expect(result.nodes.length).toBe(1);
     expect(result.nodes[0].frameUrl).toBe('https://x.com/dialog');
+  });
+});
+
+describe('buildSnapshotOutput — M2 priorities', () => {
+  it('upgraded node emits upgrade.role and upgrade.name', () => {
+    const frames: RawFrameAX[] = [{
+      frameId: 'main', frameUrl: 'https://x.com', isMainFrame: true,
+      nodes: [ax('a1', 'generic', '', 100)],
+    }];
+    const base = mergeAxData(frames);
+    const domLookup: DomLookup = new Map();
+    domLookup.set(100, dom({ backendNodeId: 100, tag: 'div', cursorStyle: 'pointer' }));
+    domLookup.set(101, dom({ backendNodeId: 101, parentBackendNodeId: 100, nodeType: 3, nodeValue: 'Filter' }));
+
+    const merged = mergeDomSnapshot(base, domLookup, new Map([['main', 'https://x.com']]), 'main');
+    const output = buildSnapshotOutput(merged.nodes, merged.axIdToUid);
+
+    const node = output.idToNode.get('1')!;
+    expect(node.role).toBe('button');
+    expect(node.name).toBe('Filter');
+  });
+
+  it('inferred node emits inferred.role/name and skips children', () => {
+    const frames: RawFrameAX[] = [{
+      frameId: 'main', frameUrl: 'https://x.com', isMainFrame: true, nodes: [],
+    }];
+    const base = mergeAxData(frames);
+    const domLookup: DomLookup = new Map();
+    domLookup.set(700, dom({ backendNodeId: 700, tag: 'div', cursorStyle: 'pointer' }));
+    domLookup.set(701, dom({ backendNodeId: 701, parentBackendNodeId: 700, nodeType: 3, nodeValue: 'Click' }));
+
+    const merged = mergeDomSnapshot(base, domLookup, new Map([['main', 'https://x.com']]), 'main');
+    const output = buildSnapshotOutput(merged.nodes, merged.axIdToUid);
+
+    const node = output.idToNode.get('1')!;
+    expect(node.role).toBe('button');
+    expect(node.name).toBe('Click');
+    expect(node.children).toBeUndefined();
   });
 });

--- a/tests/unit/snapshot-merge.test.ts
+++ b/tests/unit/snapshot-merge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mergeAXData } from '../../packages/runtime/src/internal/primitives/snapshot/merge.js';
+import { mergeAxData } from '../../packages/runtime/src/internal/primitives/snapshot/merge.js';
 import type { RawFrameAX } from '../../packages/runtime/src/internal/primitives/snapshot/types.js';
 
 function axNode(nodeId: string, role: string, name: string, backendDOMNodeId?: number, extra?: any) {
@@ -14,14 +14,14 @@ function axNode(nodeId: string, role: string, name: string, backendDOMNodeId?: n
   };
 }
 
-describe('mergeAXData', () => {
+describe('mergeAxData', () => {
   it('assigns sequential uids across frames', () => {
     const data: RawFrameAX[] = [
       { frameId: 'main', frameUrl: 'https://example.com', isMainFrame: true, nodes: [axNode('a1', 'button', 'OK', 100)] },
       { frameId: 'iframe', frameUrl: 'https://example.com/form', isMainFrame: false, nodes: [axNode('b1', 'textbox', 'Name', 200)] },
     ];
 
-    const result = mergeAXData(data);
+    const result = mergeAxData(data);
 
     expect(result.nodes).toHaveLength(2);
     expect(result.nodes[0].uid).toBe('1');
@@ -34,7 +34,7 @@ describe('mergeAXData', () => {
       { frameId: 'iframe', frameUrl: 'https://example.com/form', isMainFrame: false, nodes: [axNode('b1', 'textbox', 'Name', 200)] },
     ];
 
-    const result = mergeAXData(data);
+    const result = mergeAxData(data);
 
     expect(result.nodes[0].frameUrl).toBeUndefined();
     expect(result.nodes[1].frameUrl).toBe('https://example.com/form');
@@ -48,7 +48,7 @@ describe('mergeAXData', () => {
       ]},
     ];
 
-    const result = mergeAXData(data);
+    const result = mergeAxData(data);
 
     expect(result.uidToBackendNodeId.get('1')).toBe(101);
     expect(result.uidToBackendNodeId.get('2')).toBe(102);
@@ -62,7 +62,7 @@ describe('mergeAXData', () => {
       ]},
     ];
 
-    const result = mergeAXData(data);
+    const result = mergeAxData(data);
 
     expect(result.nodes).toHaveLength(1);
     expect(result.nodes[0].uid).toBe('1');
@@ -77,7 +77,7 @@ describe('mergeAXData', () => {
       ]},
     ];
 
-    const result = mergeAXData(data);
+    const result = mergeAxData(data);
 
     expect(result.nodes).toHaveLength(1);
   });
@@ -89,7 +89,7 @@ describe('mergeAXData', () => {
       ]},
     ];
 
-    const result = mergeAXData(data);
+    const result = mergeAxData(data);
 
     expect(result.nodes).toHaveLength(1);
     expect(result.uidToBackendNodeId.has('1')).toBe(false);
@@ -101,7 +101,7 @@ describe('mergeAXData', () => {
       { frameId: 'iframe', frameUrl: 'https://example.com/form', isMainFrame: false, nodes: [axNode('a1', 'textbox', 'Name', 200)] },
     ];
 
-    const result = mergeAXData(data);
+    const result = mergeAxData(data);
 
     // Same nodeId 'a1' in different frames should map to different uids
     expect(result.axIdToUid.get('main:a1')).toBe('1');
@@ -114,7 +114,7 @@ describe('mergeAXData', () => {
       { frameId: 'empty', frameUrl: 'https://example.com/empty', isMainFrame: false, nodes: [] },
     ];
 
-    const result = mergeAXData(data);
+    const result = mergeAxData(data);
 
     expect(result.nodes).toHaveLength(1);
   });


### PR DESCRIPTION
## Summary

Extends the M1 5-stage snapshot pipeline (fetch / hydrate / merge / filter / output) to surface Vue/React `<div @click>` elements that are invisible to AX-only snapshots. Triggered by a real onboarding where 100% of filter triggers are non-semantic Vue divs.

- **fetch**: parallel `DOMSnapshot.captureSnapshot` (one CDP call covers all same-origin documents). Graceful degradation on older Chrome.
- **hydrate**: SoA decoder produces `Map<backendNodeId, DomEntry>` with tag/attributes/bounds/cursor/isClickable. RareBooleanData -> Set for O(1) lookup (browser-use perf note).
- **merge**: cross-join via backendNodeId. AX role=generic/'' nodes get **upgraded** to `role:'button'` with DOM-derived name; AX-orphan interactives get **injected** as fresh MergedNodes.
- **detector**: ~150 line TS port of `clickable_elements.py` from browser-use. 9 heuristic branches (interactive_tags, AX role/properties, role attr, interactive attrs, search indicators, icon size, label/span+form-control descendant, isClickable, cursor:pointer). `has_js_click_listener` sourced from DOMSnapshot.isClickable (zero extra CDP cost) instead of Runtime.evaluate getEventListeners.
- **output**: role/name priority chain (upgrade > inferred > AX). Inferred nodes skip AX-only paths (childIds, properties, value).
- **default-on, no flag**: Twitter regression covered by golden fixtures.

## Files

- New: `clickable-detector.ts` (port), `derive-name.ts` (BFS text aggregation), 4 unit test files
- Extended: `types.ts`, `fetch.ts`, `hydrate.ts`, `merge.ts`, `output.ts`, `puppeteer-backend.ts`
- Click/type/scroll execution paths unchanged; `Primitives` interface unchanged; `SnapshotNode` shape unchanged.

## Test Plan

- [x] 465/465 unit tests pass (49 files)
- [x] tsc clean (root + packages/runtime)
- [x] pnpm build succeeds
- [x] Twitter golden fixtures unchanged